### PR TITLE
Add Additional Options Parameter

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -1,4 +1,5 @@
 /*jshint maxcomplexity:15*/
+/*jshint -W072 */
 var domain = require('domain');
 
 var caching = function(args) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -36,9 +36,10 @@ var caching = function(args) {
      *       console.log(user);
      *   });
      */
-    self.wrap = function(key, work, ttl, cb) {
+    self.wrap = function(key, work, ttl, cb, options) {
         if (typeof ttl === 'function') {
             cb = ttl;
+            options = cb;
             ttl = undefined;
         }
 
@@ -79,10 +80,10 @@ var caching = function(args) {
                         } else {
                             fillCallbacks(null, data);
                         }
-                    });
+                    }, options);
                 });
             }
-        });
+        }, options);
     };
 
     self.get = self.store.get.bind(self.store);

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -37,11 +37,10 @@ var caching = function(args) {
      *       console.log(user);
      *   });
      */
-    self.wrap = function(key, work, ttl, cb, options) {
-        if (typeof ttl === 'function') {
-            cb = ttl;
-            options = cb;
-            ttl = undefined;
+    self.wrap = function(key, work, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = undefined;
         }
 
         if (self.queues[key]) {
@@ -59,7 +58,7 @@ var caching = function(args) {
             delete self.queues[key];
         }
 
-        self.store.get(key, function(err, result) {
+        self.store.get(key, options, function(err, result) {
             if (err && (!self.ignoreCacheErrors)) {
                 fillCallbacks(err);
             } else if (result) {
@@ -75,16 +74,16 @@ var caching = function(args) {
                         fillCallbacks(err);
                         return;
                     }
-                    self.store.set(key, data, ttl, function(err) {
+                    self.store.set(key, data, options, function(err) {
                         if (err && (!self.ignoreCacheErrors)) {
                             fillCallbacks(err);
                         } else {
                             fillCallbacks(null, data);
                         }
-                    }, options);
+                    });
                 });
             }
-        }, options);
+        });
     };
 
     self.get = self.store.get.bind(self.store);

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -6,31 +6,60 @@ var domain = require('domain');
 /**
  * Module that lets you specify a hierarchy of caches.
  */
-var multi_caching = function(caches) {
+var multi_caching = function (caches) {
     var self = {};
-    if (!Array.isArray(caches)) { throw new Error('multi_caching requires an array of caches'); }
+    if (!Array.isArray(caches)) {
+        throw new Error('multi_caching requires an array of caches');
+    }
 
     self.queues = {};
 
-    function get_from_highest_priority_cache(key, cb, options) {
-        var i = 0;
-        async.forEachSeries(caches, function(cache, async_cb) {
-            cache.store.get(key, function(err, result) {
-                if (err) { return cb(err); }
-                if (result) {
-                    // break out of async loop.
-                    return cb(err, result, i);
-                }
+    function get_from_highest_priority_cache(key, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = undefined;
+        }
 
-                i += 1;
-                async_cb(err);
-            }, options);
+        var i = 0;
+        async.forEachSeries(caches, function (cache, async_cb) {
+            if(typeof options === 'object'){
+                cache.store.get(key, options, function (err, result) {
+                    if (err) {
+                        return cb(err);
+                    }
+                    if (result) {
+                        // break out of async loop.
+                        return cb(err, result, i);
+                    }
+
+                    i += 1;
+                    async_cb(err);
+                });
+            }else{
+                cache.store.get(key, function (err, result) {
+                    if (err) {
+                        return cb(err);
+                    }
+                    if (result) {
+                        // break out of async loop.
+                        return cb(err, result, i);
+                    }
+
+                    i += 1;
+                    async_cb(err);
+                });
+            }
+
         }, cb);
     }
 
     function set_in_multiple_caches(caches, opts, cb) {
-        async.forEach(caches, function(cache, async_cb) {
-            cache.store.set(opts.key, opts.value, opts.ttl, async_cb, opts.options);
+        async.forEach(caches, function (cache, async_cb) {
+            if (typeof opts.options !== 'object') {
+                cache.store.set(opts.key, opts.value, opts.ttl, async_cb);
+            } else {
+                cache.store.set(opts.key, opts.value, opts.options, async_cb);
+            }
         }, cb);
     }
 
@@ -39,8 +68,8 @@ var multi_caching = function(caches) {
      *
      * When a key is found in a lower cache, all higher levels are updated
      */
-    self.get_and_pass_up = function(key, cb) {
-        get_from_highest_priority_cache(key, function(err, result, index) {
+    self.get_and_pass_up = function (key, cb) {
+        get_from_highest_priority_cache(key, function (err, result, index) {
             if (err) {
                 return cb(err);
             }
@@ -49,7 +78,7 @@ var multi_caching = function(caches) {
 
             if (result !== undefined && index) {
                 var cachesToUpdate = caches.slice(0, index);
-                async.forEach(cachesToUpdate, function(cache, async_cb) {
+                async.forEach(cachesToUpdate, function (cache, async_cb) {
                     cache.set(key, result, result.ttl, async_cb);
                 });
             }
@@ -66,11 +95,10 @@ var multi_caching = function(caches) {
      * If a key doesn't exist in a higher-priority cache but exists in a lower-priority
      * cache, it gets set in all higher-priority caches.
      */
-    self.wrap = function(key, work, ttl, cb, options) {
-        if (typeof ttl === 'function') {
-            cb = ttl;
-            options = cb;
-            ttl = undefined;
+    self.wrap = function (key, work, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = undefined;
         }
 
         if (self.queues[key]) {
@@ -81,14 +109,14 @@ var multi_caching = function(caches) {
         self.queues[key] = [{cb: cb, domain: process.domain}];
 
         function fillCallbacks(err, data) {
-            self.queues[key].forEach(function(task) {
+            self.queues[key].forEach(function (task) {
                 var taskDomain = task.domain || domain.create();
                 taskDomain.bind(task.cb)(err, data);
             });
             delete self.queues[key];
         }
 
-        get_from_highest_priority_cache(key, function(err, result, index) {
+        get_from_highest_priority_cache(key, function (err, result, index) {
             if (err) {
                 return fillCallbacks(err);
             } else if (result) {
@@ -96,19 +124,23 @@ var multi_caching = function(caches) {
                 var opts = {
                     key: key,
                     value: result,
-                    ttl: ttl,
                     options: options
                 };
-                set_in_multiple_caches(caches_to_update, opts, function(err) {
+
+                if (typeof options !== 'object') {
+                    opts.ttl = options;
+                }
+
+                set_in_multiple_caches(caches_to_update, opts, function (err) {
                     fillCallbacks(err, result);
                 });
             } else {
                 domain
-                .create()
-                .on('error', function(err) {
-                    fillCallbacks(err);
-                })
-                .bind(work)(function(err, data) {
+                    .create()
+                    .on('error', function (err) {
+                        fillCallbacks(err);
+                    })
+                    .bind(work)(function (err, data) {
                     if (err) {
                         fillCallbacks(err);
                         return;
@@ -116,10 +148,13 @@ var multi_caching = function(caches) {
                     var opts = {
                         key: key,
                         value: data,
-                        ttl: ttl,
                         options: options
                     };
-                    set_in_multiple_caches(caches, opts, function(err) {
+
+                    if (typeof options !== 'object') {
+                        opts.ttl = options;
+                    }
+                    set_in_multiple_caches(caches, opts, function (err) {
                         if (err) {
                             fillCallbacks(err);
                         } else {
@@ -131,23 +166,37 @@ var multi_caching = function(caches) {
         });
     };
 
-    self.set = function(key, value, ttl, cb, options) {
+    self.set = function (key, value, options, cb) {
         var opts = {
             key: key,
             value: value,
-            ttl: ttl,
             options: options
         };
+        if (typeof options !== 'object') {
+            opts.ttl = options;
+        }
         set_in_multiple_caches(caches, opts, cb);
     };
 
-    self.get = function(key, cb, options) {
-        get_from_highest_priority_cache(key, cb, options);
+    self.get = function (key, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = false;
+        }
+        get_from_highest_priority_cache(key, options, cb);
     };
 
-    self.del = function(key, cb, options) {
-        async.forEach(caches, function(cache, async_cb) {
-            cache.store.del(key, async_cb, options);
+    self.del = function (key, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = false;
+        }
+        async.forEach(caches, function (cache, async_cb) {
+            if(typeof options ==='object'){
+                cache.store.del(key, options, async_cb );
+            }else{
+                cache.store.del(key, async_cb );
+            }
         }, cb);
     };
 

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -1,12 +1,10 @@
-/*jshint -W072 */
-
 var async = require('async');
 var domain = require('domain');
 
 /**
  * Module that lets you specify a hierarchy of caches.
  */
-var multi_caching = function (caches) {
+var multi_caching = function(caches) {
     var self = {};
     if (!Array.isArray(caches)) {
         throw new Error('multi_caching requires an array of caches');
@@ -21,40 +19,29 @@ var multi_caching = function (caches) {
         }
 
         var i = 0;
-        async.forEachSeries(caches, function (cache, async_cb) {
-            if(typeof options === 'object'){
-                cache.store.get(key, options, function (err, result) {
-                    if (err) {
-                        return cb(err);
-                    }
-                    if (result) {
-                        // break out of async loop.
-                        return cb(err, result, i);
-                    }
+        async.forEachSeries(caches, function(cache, async_cb) {
+            var callback = function(err, result) {
+                if (err) {
+                    return cb(err);
+                }
+                if (result) {
+                    // break out of async loop.
+                    return cb(err, result, i);
+                }
 
-                    i += 1;
-                    async_cb(err);
-                });
-            }else{
-                cache.store.get(key, function (err, result) {
-                    if (err) {
-                        return cb(err);
-                    }
-                    if (result) {
-                        // break out of async loop.
-                        return cb(err, result, i);
-                    }
-
-                    i += 1;
-                    async_cb(err);
-                });
+                i += 1;
+                async_cb(err);
+            };
+            if (typeof options === 'object') {
+                cache.store.get(key, options, callback);
+            }else {
+                cache.store.get(key, callback);
             }
-
         }, cb);
     }
 
     function set_in_multiple_caches(caches, opts, cb) {
-        async.forEach(caches, function (cache, async_cb) {
+        async.forEach(caches, function(cache, async_cb) {
             if (typeof opts.options !== 'object') {
                 cache.store.set(opts.key, opts.value, opts.ttl, async_cb);
             } else {
@@ -68,8 +55,8 @@ var multi_caching = function (caches) {
      *
      * When a key is found in a lower cache, all higher levels are updated
      */
-    self.get_and_pass_up = function (key, cb) {
-        get_from_highest_priority_cache(key, function (err, result, index) {
+    self.get_and_pass_up = function(key, cb) {
+        get_from_highest_priority_cache(key, function(err, result, index) {
             if (err) {
                 return cb(err);
             }
@@ -78,7 +65,7 @@ var multi_caching = function (caches) {
 
             if (result !== undefined && index) {
                 var cachesToUpdate = caches.slice(0, index);
-                async.forEach(cachesToUpdate, function (cache, async_cb) {
+                async.forEach(cachesToUpdate, function(cache, async_cb) {
                     cache.set(key, result, result.ttl, async_cb);
                 });
             }
@@ -95,7 +82,7 @@ var multi_caching = function (caches) {
      * If a key doesn't exist in a higher-priority cache but exists in a lower-priority
      * cache, it gets set in all higher-priority caches.
      */
-    self.wrap = function (key, work, options, cb) {
+    self.wrap = function(key, work, options, cb) {
         if (typeof options === 'function') {
             cb = options;
             options = undefined;
@@ -109,14 +96,14 @@ var multi_caching = function (caches) {
         self.queues[key] = [{cb: cb, domain: process.domain}];
 
         function fillCallbacks(err, data) {
-            self.queues[key].forEach(function (task) {
+            self.queues[key].forEach(function(task) {
                 var taskDomain = task.domain || domain.create();
                 taskDomain.bind(task.cb)(err, data);
             });
             delete self.queues[key];
         }
 
-        get_from_highest_priority_cache(key, function (err, result, index) {
+        get_from_highest_priority_cache(key, function(err, result, index) {
             if (err) {
                 return fillCallbacks(err);
             } else if (result) {
@@ -131,16 +118,16 @@ var multi_caching = function (caches) {
                     opts.ttl = options;
                 }
 
-                set_in_multiple_caches(caches_to_update, opts, function (err) {
+                set_in_multiple_caches(caches_to_update, opts, function(err) {
                     fillCallbacks(err, result);
                 });
             } else {
                 domain
                     .create()
-                    .on('error', function (err) {
+                    .on('error', function(err) {
                         fillCallbacks(err);
                     })
-                    .bind(work)(function (err, data) {
+                    .bind(work)(function(err, data) {
                     if (err) {
                         fillCallbacks(err);
                         return;
@@ -154,7 +141,7 @@ var multi_caching = function (caches) {
                     if (typeof options !== 'object') {
                         opts.ttl = options;
                     }
-                    set_in_multiple_caches(caches, opts, function (err) {
+                    set_in_multiple_caches(caches, opts, function(err) {
                         if (err) {
                             fillCallbacks(err);
                         } else {
@@ -166,7 +153,7 @@ var multi_caching = function (caches) {
         });
     };
 
-    self.set = function (key, value, options, cb) {
+    self.set = function(key, value, options, cb) {
         var opts = {
             key: key,
             value: value,
@@ -178,7 +165,7 @@ var multi_caching = function (caches) {
         set_in_multiple_caches(caches, opts, cb);
     };
 
-    self.get = function (key, options, cb) {
+    self.get = function(key, options, cb) {
         if (typeof options === 'function') {
             cb = options;
             options = false;
@@ -186,16 +173,16 @@ var multi_caching = function (caches) {
         get_from_highest_priority_cache(key, options, cb);
     };
 
-    self.del = function (key, options, cb) {
+    self.del = function(key, options, cb) {
         if (typeof options === 'function') {
             cb = options;
             options = false;
         }
-        async.forEach(caches, function (cache, async_cb) {
-            if(typeof options ==='object'){
-                cache.store.del(key, options, async_cb );
-            }else{
-                cache.store.del(key, async_cb );
+        async.forEach(caches, function(cache, async_cb) {
+            if (typeof options === 'object') {
+                cache.store.del(key, options, async_cb);
+            }else {
+                cache.store.del(key, async_cb);
             }
         }, cb);
     };

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -1,3 +1,5 @@
+/*jshint -W072 */
+
 var async = require('async');
 var domain = require('domain');
 

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -10,7 +10,7 @@ var multi_caching = function(caches) {
 
     self.queues = {};
 
-    function get_from_highest_priority_cache(key, cb) {
+    function get_from_highest_priority_cache(key, cb, options) {
         var i = 0;
         async.forEachSeries(caches, function(cache, async_cb) {
             cache.store.get(key, function(err, result) {
@@ -22,13 +22,13 @@ var multi_caching = function(caches) {
 
                 i += 1;
                 async_cb(err);
-            });
+            }, options);
         }, cb);
     }
 
     function set_in_multiple_caches(caches, opts, cb) {
         async.forEach(caches, function(cache, async_cb) {
-            cache.store.set(opts.key, opts.value, opts.ttl, async_cb);
+            cache.store.set(opts.key, opts.value, opts.ttl, async_cb, opts.options);
         }, cb);
     }
 
@@ -64,9 +64,10 @@ var multi_caching = function(caches) {
      * If a key doesn't exist in a higher-priority cache but exists in a lower-priority
      * cache, it gets set in all higher-priority caches.
      */
-    self.wrap = function(key, work, ttl, cb) {
+    self.wrap = function(key, work, ttl, cb, options) {
         if (typeof ttl === 'function') {
             cb = ttl;
+            options = cb;
             ttl = undefined;
         }
 
@@ -93,7 +94,8 @@ var multi_caching = function(caches) {
                 var opts = {
                     key: key,
                     value: result,
-                    ttl: ttl
+                    ttl: ttl,
+                    options: options
                 };
                 set_in_multiple_caches(caches_to_update, opts, function(err) {
                     fillCallbacks(err, result);
@@ -112,7 +114,8 @@ var multi_caching = function(caches) {
                     var opts = {
                         key: key,
                         value: data,
-                        ttl: ttl
+                        ttl: ttl,
+                        options: options
                     };
                     set_in_multiple_caches(caches, opts, function(err) {
                         if (err) {
@@ -126,22 +129,23 @@ var multi_caching = function(caches) {
         });
     };
 
-    self.set = function(key, value, ttl, cb) {
+    self.set = function(key, value, ttl, cb, options) {
         var opts = {
             key: key,
             value: value,
-            ttl: ttl
+            ttl: ttl,
+            options: options
         };
         set_in_multiple_caches(caches, opts, cb);
     };
 
-    self.get = function(key, cb) {
-        get_from_highest_priority_cache(key, cb);
+    self.get = function(key, cb, options) {
+        get_from_highest_priority_cache(key, cb, options);
     };
 
-    self.del = function(key, cb) {
+    self.del = function(key, cb, options) {
         async.forEach(caches, function(cache, async_cb) {
-            cache.store.del(key, async_cb);
+            cache.store.del(key, async_cb, options);
         }, cb);
     };
 

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -12,14 +12,17 @@ var memory_store = function(args) {
 
     var lru_cache = new Lru(lru_opts);
 
-    self.set = function(key, value, ttl, cb) {
+    self.set = function(key, value, options, cb) {
         lru_cache.set(key, value);
         if (cb) {
             process.nextTick(cb);
         }
     };
 
-    self.get = function(key, cb) {
+    self.get = function(key, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+        }
         var value = lru_cache.get(key);
         if (cb) {
             process.nextTick(function() {
@@ -30,7 +33,10 @@ var memory_store = function(args) {
         }
     };
 
-    self.del = function(key, cb) {
+    self.del = function(key, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+        }
         lru_cache.del(key);
         if (cb) {
             process.nextTick(cb);

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -379,7 +379,7 @@ describe("caching", function() {
                     it("bubbles up that error", function(done) {
                         var fake_error = new Error(support.random.string());
 
-                        sinon.stub(memory_store_stub, 'get', function(key, cb) {
+                        sinon.stub(memory_store_stub, 'get', function(key, options, cb) {
                             cb(fake_error);
                         });
 
@@ -399,7 +399,7 @@ describe("caching", function() {
 
                         var fake_error = new Error(support.random.string());
 
-                        sinon.stub(memory_store_stub, 'get', function(key, cb) {
+                        sinon.stub(memory_store_stub, 'get', function(key, options, cb) {
                             cb(fake_error);
                         });
 

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -172,8 +172,8 @@ describe("multi_caching", function() {
                                 });
                             });
                         });
-                    });
-                }, 10);
+                    }, 10);
+                });
             });
         });
     });

--- a/test/stores/options.unit.js
+++ b/test/stores/options.unit.js
@@ -1,0 +1,134 @@
+var caching = require("../../index");
+var assert = require("assert");
+var support = require('../support');
+var memoryFlag = "";
+var key;
+var value;
+var testStore = function(args) {
+    args = args || {};
+    var self = {};
+    self.name = "options";
+
+    self.get = function(key, cb, options) {
+        if (options && options.value) {
+            return cb(null, options.value + "ValueOption");
+        } else if (options && options.fn) {
+            options.fn("GetFunctionOption");
+            return cb(null, "GetFunctionOption");
+        }
+        return cb("Error No Options");
+    };
+
+    self.set = function(key, value, ttl, cb, options) {
+        if (options && options.value) {
+            memoryFlag = options.value + "ValueOption";
+            return cb();
+        } else if (options && options.fn) {
+            options.fn("SetFunctionOption");
+            return cb();
+        }
+        return cb("Error No Options");
+    };
+
+    self.del = function(key, cb, options) {
+        if (options && options.value) {
+            memoryFlag = options.value + "ValueOption";
+            return cb();
+        } else if (options && options.fn) {
+            options.fn("DeleteFunctionOption");
+            return cb();
+        }
+        return cb("Error No Options");
+    };
+
+    return {
+        create: function() {
+            return self;
+        }
+    };
+};
+
+describe("Methods with options", function() {
+    before(function() {
+        key = support.random.string(20);
+        value = support.random.string(20);
+    });
+    describe("get with options", function() {
+        var testInstance = caching.caching({store: testStore()});
+        var testCache;
+        before(function() {
+            testCache = caching.multi_caching([testInstance]);
+        });
+
+        it("lets us pass options by value", function(done) {
+            var options = {value: value};
+            testCache.get(key, function(err, response) {
+                assert.equal(response, value + "ValueOption");
+                done();
+            }, options);
+        });
+
+        it("lets us pass options by function", function(done) {
+            var options = {
+                fn: function(response) {
+                    assert.equal(response, "GetFunctionOption");
+                    done();
+                }
+            };
+            testCache.get(key, function(err, response) {
+                assert.equal(response, "GetFunctionOption");
+            }, options);
+        });
+    });
+    describe("set with options", function() {
+        var testInstance = caching.caching({store: testStore()});
+        var testCache;
+        var ttl = 60;
+        before(function() {
+            testCache = caching.multi_caching([testInstance]);
+        });
+
+        it("lets us pass options by value", function(done) {
+            var options = {value: value};
+            testCache.set(key, value, ttl, function() {
+                assert.equal(memoryFlag,value + "ValueOption");
+                done();
+            }, options);
+        });
+
+        it("lets us pass options by function", function(done) {
+            var options = {
+                fn: function(response) {
+                    assert.equal(response, "SetFunctionOption");
+                    done();
+                }
+            };
+            testCache.set(key, value, ttl, function() {}, options);
+        });
+    });
+    describe("delete with options", function() {
+        var testInstance = caching.caching({store: testStore()});
+        var testCache;
+        before(function() {
+            testCache = caching.multi_caching([testInstance]);
+        });
+
+        it("lets us pass options by value", function(done) {
+            var options = {value: value};
+            testCache.del(key, function() {
+                assert.equal(memoryFlag,value + "ValueOption");
+                done();
+            }, options);
+        });
+
+        it("lets us pass options by function", function(done) {
+            var options = {
+                fn: function(response) {
+                    assert.equal(response, "DeleteFunctionOption");
+                    done();
+                }
+            };
+            testCache.del(key, function() {}, options);
+        });
+    });
+});

--- a/test/stores/options.unit.js
+++ b/test/stores/options.unit.js
@@ -37,7 +37,7 @@ var testStore = function(args) {
             cb = options;
             options = false;
             optionsMapped = true;
-        } else if (typeof options !== 'object') {
+        } else if (typeof options !== "object") {
             options = {ttl: options, runNormal: true};
         }
         if (options && options.value) {

--- a/test/stores/options.unit.js
+++ b/test/stores/options.unit.js
@@ -1,5 +1,3 @@
-/*jshint -W072 */
-
 var caching = require("../../index");
 var assert = require("assert");
 var support = require('../support');
@@ -77,7 +75,7 @@ describe("Methods with options", function() {
                     done();
                 }
             };
-            testCache.get(key , options, function(err, response) {
+            testCache.get(key, options, function(err, response) {
                 assert.equal(response, "GetFunctionOption");
             });
         });

--- a/test/stores/options.unit.js
+++ b/test/stores/options.unit.js
@@ -1,3 +1,5 @@
+/*jshint -W072 */
+
 var caching = require("../../index");
 var assert = require("assert");
 var support = require('../support');

--- a/test/stores/options.unit.js
+++ b/test/stores/options.unit.js
@@ -11,7 +11,7 @@ var testStore = function(args) {
     var self = {};
     self.name = "options";
 
-    self.get = function(key, cb, options) {
+    self.get = function(key, options, cb) {
         if (options && options.value) {
             return cb(null, options.value + "ValueOption");
         } else if (options && options.fn) {
@@ -21,7 +21,7 @@ var testStore = function(args) {
         return cb("Error No Options");
     };
 
-    self.set = function(key, value, ttl, cb, options) {
+    self.set = function(key, value, options, cb) {
         if (options && options.value) {
             memoryFlag = options.value + "ValueOption";
             return cb();
@@ -32,7 +32,7 @@ var testStore = function(args) {
         return cb("Error No Options");
     };
 
-    self.del = function(key, cb, options) {
+    self.del = function(key, options, cb) {
         if (options && options.value) {
             memoryFlag = options.value + "ValueOption";
             return cb();
@@ -64,10 +64,10 @@ describe("Methods with options", function() {
 
         it("lets us pass options by value", function(done) {
             var options = {value: value};
-            testCache.get(key, function(err, response) {
+            testCache.get(key, options, function(err, response) {
                 assert.equal(response, value + "ValueOption");
                 done();
-            }, options);
+            });
         });
 
         it("lets us pass options by function", function(done) {
@@ -77,9 +77,9 @@ describe("Methods with options", function() {
                     done();
                 }
             };
-            testCache.get(key, function(err, response) {
+            testCache.get(key , options, function(err, response) {
                 assert.equal(response, "GetFunctionOption");
-            }, options);
+            });
         });
     });
     describe("set with options", function() {
@@ -91,21 +91,22 @@ describe("Methods with options", function() {
         });
 
         it("lets us pass options by value", function(done) {
-            var options = {value: value};
-            testCache.set(key, value, ttl, function() {
-                assert.equal(memoryFlag,value + "ValueOption");
+            var options = {ttl: ttl, value: value};
+            testCache.set(key, value, options, function() {
+                assert.equal(memoryFlag, value + "ValueOption");
                 done();
-            }, options);
+            });
         });
 
         it("lets us pass options by function", function(done) {
             var options = {
+                ttl: ttl,
                 fn: function(response) {
                     assert.equal(response, "SetFunctionOption");
                     done();
                 }
             };
-            testCache.set(key, value, ttl, function() {}, options);
+            testCache.set(key, value, options, function() {}, options);
         });
     });
     describe("delete with options", function() {
@@ -117,10 +118,10 @@ describe("Methods with options", function() {
 
         it("lets us pass options by value", function(done) {
             var options = {value: value};
-            testCache.del(key, function() {
+            testCache.del(key, options, function() {
                 assert.equal(memoryFlag,value + "ValueOption");
                 done();
-            }, options);
+            });
         });
 
         it("lets us pass options by function", function(done) {
@@ -130,7 +131,7 @@ describe("Methods with options", function() {
                     done();
                 }
             };
-            testCache.del(key, function() {}, options);
+            testCache.del(key, options, function() {}, options);
         });
     });
 });


### PR DESCRIPTION
Add the ability to pass in options.  These options can then be used by the stores.
Our use case is using Riak as a distributed fault tolerant cache.
We want to pass in if quorum is required for writes, read or deletes.

A get request would look like:
```
cache.get('ActiveLock', function(err, val){}, {quorum: true});
```

Also there is a test case fixed in ef044b8  The timeout parameter was on the wrong closing curly brace.

