### PR TITLE
Pass dispose, length & stale options to lru-cache

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -7,7 +7,10 @@ var memoryStore = function(args) {
     var ttl = args.ttl;
     var lruOpts = {
         max: args.max || 500,
-        maxAge: ttl ? ttl * 1000 : null
+        maxAge: ttl ? ttl * 1000 : null,
+        dispose: args.dispose,
+        length: args.length,
+        stale: args.stale
     };
 
     var lruCache = new Lru(lruOpts);


### PR DESCRIPTION
The length option is particularly useful with lru-cache if you want to store large objects of varying size and limit memory usage.
https://github.com/isaacs/node-lru-cache#options