### PR TITLE
Fix redis store TTL

### DIFF
--- a/examples/redis_example/redis_store.js
+++ b/examples/redis_example/redis_store.js
@@ -67,7 +67,11 @@ function redisStore(args) {
         }
         options = options || {};
 
-        var ttl = (options.ttl || options.ttl === 0) ? options.ttl : ttlDefault;
+        if( options >= 0 ) {
+            var ttl = options;
+        }else{
+            var ttl = (options.ttl || options.ttl === 0) ? options.ttl : ttlDefault;
+        }
 
         connect(function(err, conn) {
             if (err) { return cb(err); }

--- a/examples/redis_example/redis_store.js
+++ b/examples/redis_example/redis_store.js
@@ -67,9 +67,9 @@ function redisStore(args) {
         }
         options = options || {};
 
-        if( options >= 0 ) {
+        if (options >= 0) {
             var ttl = options;
-        }else{
+        } else {
             var ttl = (options.ttl || options.ttl === 0) ? options.ttl : ttlDefault;
         }
 


### PR DESCRIPTION
Hello Bryan,

On redis store example when you set custom TTL with ``set`` function.

It doesn't work because ``set`` function check for ``options.ttl`` key and it doesn't check if the options parameter is numeric.