### PR TITLE
Stores can override isCacheableValue

### DIFF
--- a/examples/redis_example/redis_store.js
+++ b/examples/redis_example/redis_store.js
@@ -110,6 +110,10 @@ function redisStore(args) {
         });
     };
 
+    self.isCacheableValue = function(value) {
+        return value !== null && value !== undefined;
+    };
+
     return self;
 }
 

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -34,6 +34,8 @@ var caching = function(args) {
 
     if (typeof args.isCacheableValue === 'function') {
         self._isCacheableValue = args.isCacheableValue;
+    } else if (typeof self.store.isCacheableValue === 'function') {
+        self._isCacheableValue = self.store.isCacheableValue;
     } else {
         self._isCacheableValue = function(value) {
             return value !== undefined;

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -707,4 +707,25 @@ describe("caching", function() {
             });
         });
     });
+
+    describe("overloading with custom store", function() {
+        it("allows us to override isCacheableValue", function(done) {
+            var store = memoryStore.create({ttl: defaultTtl});
+            var onlyOne = true;
+            store.isCacheableValue = function(result) {
+                if (onlyOne) {
+                    onlyOne = false;
+                    done();
+                }
+                return result !== undefined;
+            };
+            cache = caching({store: store});
+            cache.wrap(key, function(cb) {
+                methods.getWidget(name, cb);
+            }, function(err, widget) {
+                checkErr(err);
+                assert.deepEqual(widget, {name: name});
+            });
+        });
+    });
 });


### PR DESCRIPTION
Potential issue was instroduced on https://github.com/BryanDonovan/node-cache-manager/commit/f3809c8b762b38e8ce0a22155b528e419b5602fc using Redis stores and wrap.
This was done following the bug report https://github.com/BryanDonovan/node-cache-manager/issues/25 I'm sorry I was not able to confirm the fix so I made this PR

Using Redis, null is returned from cache when data does not exists
In other stores, null can still be stored and undefined used when data does not exist

The issue occurs only when calling wrap in simple cache, not multi cache so I guess multi cache do not use isCacheableValue

This PR includes:
  - Each store can implement its own custom method
  - Tests to keep coverage to 100%
  - Updated redis cache exemple with the override since redis can return null when data does not exists