### PR TITLE
trying to fix #28 by checking if callbackFiller has key in domain.error

### DIFF
--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -163,7 +163,11 @@ var multiCaching = function(caches, options) {
                 domain
                 .create()
                 .on('error', function(err) {
-                    callbackFiller.fill(key, err);
+                    if (callbackFiller.has(key)) {
+                        callbackFiller.fill(key, err);
+                    } else {
+                        cb(err);
+                    }
                 })
                 .bind(work)(function(err, data) {
                     if (err) {

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -388,6 +388,7 @@ describe("multiCaching", function() {
                         checkErr(err);
                         assert.deepEqual(widget, {name: name});
                         sinon.assert.calledWith(memoryCache3.store.set, key, {name: name}, {ttl: defaultTtl});
+
                         done();
                     });
                 });
@@ -861,6 +862,31 @@ describe("multiCaching", function() {
                         throw fakeError;
                     }, ttl, function(err) {
                         assert.equal(err, fakeError);
+                        done();
+                    });
+                });
+            });
+
+            context("when an error is thrown in the work function's callback", function() {
+                var fakeError;
+
+                beforeEach(function() {
+                    fakeError = new Error(support.random.string());
+                });
+
+                it("bubbles up that error", function(done) {
+                    multiCache.wrap(key, function(next) {
+                        next();
+                    }, ttl, function() {
+                        // This test as-is doesn't prove a fix for #28 (https://github.com/BryanDonovan/node-cache-manager/issues/28)
+                        // but if you remove the try/catch, it shows that the undefined `waiting` array issue
+                        // is no longer present (the domain doesn't try to process the error in the callbackFiller).
+                        try {
+                            throw new Error('foo');
+                        } catch (e) {
+                            assert.equal(e.message, 'foo');
+                        }
+
                         done();
                     });
                 });


### PR DESCRIPTION
Hopeful fix for https://github.com/BryanDonovan/node-cache-manager/issues/28

CC @diversario, @danagle

You can test this by putting this in your package.json:

```json
 "node-cache-manager": "git+ssh://git@github.com:BryanDonovan/node-cache-manager.git#feature/fix-domain-errors"
```