### PR TITLE
Promise support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -59,7 +59,7 @@
     "expr"          : false,  // Tolerate `ExpressionStatement` as Programs.
     "forin"         : false,  // Tolerate `for in` loops without `hasOwnProperty`.
     "immed"         : true,   // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
-    "latedef"       : true,   // Prohibit variable use before definition.
+    "latedef"       : "nofunc",   // Prohibit variable use before definition.
     "loopfunc"      : true,   // Allow functions to be defined within loops.
     "maxparams"     : 4,
     "maxdepth"      : 5,

--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
 
     "predef"        : [  // Extra globals.
         "__dirname",
+        "Promise",
         "Buffer",
         "event",
         "exports",

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -69,6 +69,17 @@ var caching = function(args) {
             options = {};
         }
 
+        if (!cb) {
+            cb = Promise.defer();
+            var work2 = work;
+            work = function(cb) {
+                Promise.resolve().then(work2).then(function(res) {
+                    cb(null, res);
+                })
+                .catch(cb);
+            };
+        }
+
         var hasKey = callbackFiller.has(key);
         callbackFiller.add(key, {cb: cb, domain: process.domain});
         if (hasKey) { return; }
@@ -91,6 +102,9 @@ var caching = function(args) {
                     }
 
                     if (!self._isCacheableValue(data)) {
+                        if (typeof cb === 'object') {
+                            return cb.resolve(data);
+                        }
                         return cb();
                     }
 
@@ -104,6 +118,10 @@ var caching = function(args) {
                 });
             }
         });
+
+        if (typeof cb === 'object') {
+            return cb.promise;
+        }
     };
 
     /**

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -42,6 +42,24 @@ var caching = function(args) {
         };
     }
 
+    function wrapPromise(key, promise, options) {
+        return new Promise(function(resolve, reject) {
+            self.wrap(key, function(cb) {
+                Promise.resolve()
+                .then(promise)
+                .then(function(result) {
+                    cb(null, result);
+                })
+                .catch(cb);
+            }, options, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
+        });
+    }
+
     /**
      * Wraps a function in cache. I.e., the first time the function is run,
      * its results are stored in cache so subsequent calls retrieve from cache
@@ -70,14 +88,7 @@ var caching = function(args) {
         }
 
         if (!cb) {
-            cb = Promise.defer();
-            var work2 = work;
-            work = function(cb) {
-                Promise.resolve().then(work2).then(function(res) {
-                    cb(null, res);
-                })
-                .catch(cb);
-            };
+            return wrapPromise(key, work, options);
         }
 
         var hasKey = callbackFiller.has(key);
@@ -102,9 +113,6 @@ var caching = function(args) {
                     }
 
                     if (!self._isCacheableValue(data)) {
-                        if (typeof cb === 'object') {
-                            return cb.resolve(data);
-                        }
                         return cb();
                     }
 
@@ -118,10 +126,6 @@ var caching = function(args) {
                 });
             }
         });
-
-        if (typeof cb === 'object') {
-            return cb.promise;
-        }
     };
 
     /**

--- a/lib/callback_filler.js
+++ b/lib/callback_filler.js
@@ -12,12 +12,6 @@ CallbackFiller.prototype.fill = function(key, err, data) {
 
     waiting.forEach(function(task) {
         var taskDomain = task.domain || domain.create();
-        if (typeof task.cb === 'object') {
-            if (err) {
-                return taskDomain.bind(task.cb.reject)(err);
-            }
-            return taskDomain.bind(task.cb.resolve)(data);
-        }
         taskDomain.bind(task.cb)(err, data);
     });
 };

--- a/lib/callback_filler.js
+++ b/lib/callback_filler.js
@@ -12,6 +12,12 @@ CallbackFiller.prototype.fill = function(key, err, data) {
 
     waiting.forEach(function(task) {
         var taskDomain = task.domain || domain.create();
+        if (typeof task.cb === 'object') {
+            if (err) {
+                return taskDomain.bind(task.cb.reject)(err);
+            }
+            return taskDomain.bind(task.cb.resolve)(data);
+        }
         taskDomain.bind(task.cb)(err, data);
     });
 };

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -145,6 +145,17 @@ var multiCaching = function(caches, options) {
             };
         }
 
+        if (!cb) {
+            cb = Promise.defer();
+            var work2 = work;
+            work = function(cb) {
+                Promise.resolve().then(work2).then(function(res) {
+                    cb(null, res);
+                })
+                .catch(cb);
+            };
+        }
+
         var hasKey = callbackFiller.has(key);
         callbackFiller.add(key, {cb: cb, domain: process.domain});
         if (hasKey) { return; }
@@ -175,6 +186,9 @@ var multiCaching = function(caches, options) {
                     }
 
                     if (!self._isCacheableValue(data)) {
+                        if (typeof cb === 'object') {
+                            return cb.resolve(data);
+                        }
                         return cb();
                     }
 
@@ -186,6 +200,10 @@ var multiCaching = function(caches, options) {
                 });
             }
         });
+
+        if (typeof cb === 'object') {
+            return cb.promise;
+        }
     };
 
     /**

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -132,15 +132,15 @@ var multiCaching = function(caches, options) {
      * @param {function} cb
      */
     self.getAndPassUp = function(key, cb) {
-        return getFromHighestPriorityCache(key, function(err, result, index) {
-            if (err) {
-                if (cb) {
-                    return cb(err);
-                }
-            }
+        var promised = false;
+        if (!cb) {
+            promised = true;
+            cb = Promise.defer();
+        }
 
-            if (cb) {
-                cb(err, result);
+        getFromHighestPriorityCache(key, function(err, result, index) {
+            if (err) {
+                return (!promised) ? cb(err) : cb.reject(err);
             }
 
             if (index) {
@@ -153,7 +153,13 @@ var multiCaching = function(caches, options) {
                     }
                 });
             }
+
+            return (!promised) ? cb(err, result) : cb.resolve(result);
         });
+
+        if (promised) {
+            return cb.promise;
+        }
     };
 
     /**

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -176,8 +176,6 @@ var multiCaching = function(caches, options) {
                 .on('error', function(err) {
                     if (callbackFiller.has(key)) {
                         callbackFiller.fill(key, err);
-                    } else {
-                        cb(err);
                     }
                 })
                 .bind(work)(function(err, data) {

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -47,16 +47,25 @@ var multiCaching = function(caches, options) {
         }
     }
 
+    function getFromHighestPriorityCachePromise(key, options) {
+        return new Promise(function(resolve, reject) {
+            getFromHighestPriorityCache(key, options, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
+        });
+    }
+
     function getFromHighestPriorityCache(key, options, cb) {
         if (typeof options === 'function') {
             cb = options;
             options = {};
         }
 
-        var promised = false;
         if (!cb) {
-            cb = Promise.defer();
-            promised = true;
+            return getFromHighestPriorityCachePromise(key, options);
         }
 
         var i = 0;
@@ -70,10 +79,7 @@ var multiCaching = function(caches, options) {
 
                 if (_isCacheableValue(result)) {
                     // break out of async loop.
-                    if (!promised) {
-                        return cb(err, result, i);
-                    }
-                    return cb.resolve(result);
+                    return cb(err, result, i);
                 }
 
                 i += 1;
@@ -82,25 +88,26 @@ var multiCaching = function(caches, options) {
 
             cache.store.get(key, options, callback);
         }, function(err, result) {
-            if (!promised) {
-                return cb(err, result);
-            }
-
-            return (err) ? cb.reject(err) : cb.resolve(result);
+            return cb(err, result);
         });
+    }
 
-        if (promised) {
-            return cb.promise;
-        }
+    function setInMultipleCachesPromise(caches, opts) {
+        return new Promise(function(resolve, reject) {
+            setInMultipleCaches(caches, opts, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
+        });
     }
 
     function setInMultipleCaches(caches, opts, cb) {
         opts.options = opts.options || {};
 
-        var promised = false;
         if (!cb) {
-            promised = true;
-            cb = Promise.defer();
+            return setInMultipleCachesPromise(caches, opts);
         }
 
         async.each(caches, function(cache, next) {
@@ -112,16 +119,19 @@ var multiCaching = function(caches, options) {
                 next();
             }
         }, function(err, result) {
-            if (promised) {
-                return (err) ? cb.reject(err) : cb.resolve(result);
-            } else {
-                cb(err, result);
-            }
+            cb(err, result);
         });
+    }
 
-        if (promised) {
-            return cb.promise;
-        }
+    function getAndPassUpPromise(key) {
+        return new Promise(function(resolve, reject) {
+            self.getAndPassUp(key, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
+        });
     }
 
     /**
@@ -132,15 +142,13 @@ var multiCaching = function(caches, options) {
      * @param {function} cb
      */
     self.getAndPassUp = function(key, cb) {
-        var promised = false;
         if (!cb) {
-            promised = true;
-            cb = Promise.defer();
+            return getAndPassUpPromise(key);
         }
 
         getFromHighestPriorityCache(key, function(err, result, index) {
             if (err) {
-                return (!promised) ? cb(err) : cb.reject(err);
+                return cb(err);
             }
 
             if (index) {
@@ -154,13 +162,27 @@ var multiCaching = function(caches, options) {
                 });
             }
 
-            return (!promised) ? cb(err, result) : cb.resolve(result);
+            return cb(err, result);
         });
-
-        if (promised) {
-            return cb.promise;
-        }
     };
+
+    function wrapPromise(key, promise, options) {
+        return new Promise(function(resolve, reject) {
+            self.wrap(key, function(cb) {
+                Promise.resolve()
+                .then(promise)
+                .then(function(result) {
+                    cb(null, result);
+                })
+                .catch(cb);
+            }, options, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
+        });
+    }
 
     /**
      * Wraps a function in one or more caches.
@@ -192,14 +214,7 @@ var multiCaching = function(caches, options) {
         }
 
         if (!cb) {
-            cb = Promise.defer();
-            var work2 = work;
-            work = function(cb) {
-                Promise.resolve().then(work2).then(function(res) {
-                    cb(null, res);
-                })
-                .catch(cb);
-            };
+            return wrapPromise(key, work, options);
         }
 
         var hasKey = callbackFiller.has(key);
@@ -230,9 +245,6 @@ var multiCaching = function(caches, options) {
                     }
 
                     if (!self._isCacheableValue(data)) {
-                        if (typeof cb === 'object') {
-                            return cb.resolve(data);
-                        }
                         return cb();
                     }
 
@@ -244,10 +256,6 @@ var multiCaching = function(caches, options) {
                 });
             }
         });
-
-        if (typeof cb === 'object') {
-            return cb.promise;
-        }
     };
 
     /**

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -64,7 +64,11 @@ var multiCaching = function(caches, options) {
 
                 if (_isCacheableValue(result)) {
                     // break out of async loop.
-                    return cb(err, result, i);
+                    if (typeof cb === 'function') {
+                        return cb(err, result, i);
+                    } else {
+                        return cb.resolve(result);
+                    }
                 }
 
                 i += 1;
@@ -72,7 +76,17 @@ var multiCaching = function(caches, options) {
             };
 
             cache.store.get(key, options, callback);
-        }, cb);
+        }, function(err, result) {
+            if (typeof cb === 'object') {
+                if (err) {
+                    cb.reject(err);
+                } else {
+                    cb.resolve(result);
+                }
+            } else if (typeof cb === 'function') {
+                cb(err, result);
+            }
+        });
     }
 
     function setInMultipleCaches(caches, opts, cb) {
@@ -85,7 +99,17 @@ var multiCaching = function(caches, options) {
             } else {
                 next();
             }
-        }, cb);
+        }, function(err, result) {
+            if (typeof cb === 'object') {
+                if (err) {
+                    cb.reject(err);
+                } else {
+                    cb.resolve(result);
+                }
+            } else if (typeof cb === 'function') {
+                cb(err, result);
+            }
+        });
     }
 
     /**
@@ -98,10 +122,18 @@ var multiCaching = function(caches, options) {
     self.getAndPassUp = function(key, cb) {
         getFromHighestPriorityCache(key, function(err, result, index) {
             if (err) {
-                return cb(err);
+                if (typeof cb === 'function') {
+                    return cb(err);
+                } else {
+                    return cb.reject(err);
+                }
             }
 
-            cb(err, result);
+            if (typeof cb === 'function') {
+                cb(err, result);
+            } else {
+                cb.resolve(result);
+            }
 
             if (index) {
                 var cachesToUpdate = caches.slice(0, index);
@@ -227,7 +259,11 @@ var multiCaching = function(caches, options) {
             options: options
         };
 
-        setInMultipleCaches(caches, opts, cb);
+        var defer = Promise.defer();
+
+        setInMultipleCaches(caches, opts, cb || defer);
+
+        return defer.promise;
     };
 
     /**
@@ -246,7 +282,11 @@ var multiCaching = function(caches, options) {
             options = {};
         }
 
-        getFromHighestPriorityCache(key, options, cb);
+        var defer = Promise.defer();
+
+        getFromHighestPriorityCache(key, options, cb || defer);
+
+        return defer.promise;
     };
 
     /**

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -53,7 +53,11 @@ var multiCaching = function(caches, options) {
             options = {};
         }
 
-        var defer = Promise.defer();
+        var promised = false;
+        if (!cb) {
+            cb = Promise.defer();
+            promised = true;
+        }
 
         var i = 0;
         async.eachSeries(caches, function(cache, next) {
@@ -66,10 +70,10 @@ var multiCaching = function(caches, options) {
 
                 if (_isCacheableValue(result)) {
                     // break out of async loop.
-                    if (typeof cb === 'function') {
+                    if (!promised) {
                         return cb(err, result, i);
                     }
-                    return defer.resolve(result);
+                    return cb.resolve(result);
                 }
 
                 i += 1;
@@ -78,21 +82,27 @@ var multiCaching = function(caches, options) {
 
             cache.store.get(key, options, callback);
         }, function(err, result) {
-            if (typeof cb === 'function') {
-                cb(err, result);
+            if (!promised) {
+                return cb(err, result);
             }
 
-            if (err) {
-                return defer.reject(err);
-            }
-            defer.resolve(result);
+            return (err) ? cb.reject(err) : cb.resolve(result);
         });
 
-        return defer.promise;
+        if (promised) {
+            return cb.promise;
+        }
     }
 
     function setInMultipleCaches(caches, opts, cb) {
         opts.options = opts.options || {};
+
+        var promised = false;
+        if (!cb) {
+            promised = true;
+            cb = Promise.defer();
+        }
+
         async.each(caches, function(cache, next) {
             var _isCacheableValue = getIsCacheableValueFunction(cache);
 
@@ -102,16 +112,16 @@ var multiCaching = function(caches, options) {
                 next();
             }
         }, function(err, result) {
-            if (typeof cb === 'object') {
-                if (err) {
-                    cb.reject(err);
-                } else {
-                    cb.resolve(result);
-                }
-            } else if (typeof cb === 'function') {
+            if (promised) {
+                return (err) ? cb.reject(err) : cb.resolve(result);
+            } else {
                 cb(err, result);
             }
         });
+
+        if (promised) {
+            return cb.promise;
+        }
     }
 
     /**
@@ -257,11 +267,7 @@ var multiCaching = function(caches, options) {
             options: options
         };
 
-        var defer = Promise.defer();
-
-        setInMultipleCaches(caches, opts, cb || defer);
-
-        return defer.promise;
+        return setInMultipleCaches(caches, opts, cb);
     };
 
     /**

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -53,6 +53,8 @@ var multiCaching = function(caches, options) {
             options = {};
         }
 
+        var defer = Promise.defer();
+
         var i = 0;
         async.eachSeries(caches, function(cache, next) {
             var callback = function(err, result) {
@@ -66,9 +68,8 @@ var multiCaching = function(caches, options) {
                     // break out of async loop.
                     if (typeof cb === 'function') {
                         return cb(err, result, i);
-                    } else {
-                        return cb.resolve(result);
                     }
+                    return defer.resolve(result);
                 }
 
                 i += 1;
@@ -77,16 +78,17 @@ var multiCaching = function(caches, options) {
 
             cache.store.get(key, options, callback);
         }, function(err, result) {
-            if (typeof cb === 'object') {
-                if (err) {
-                    cb.reject(err);
-                } else {
-                    cb.resolve(result);
-                }
-            } else if (typeof cb === 'function') {
+            if (typeof cb === 'function') {
                 cb(err, result);
             }
+
+            if (err) {
+                return defer.reject(err);
+            }
+            defer.resolve(result);
         });
+
+        return defer.promise;
     }
 
     function setInMultipleCaches(caches, opts, cb) {
@@ -120,19 +122,15 @@ var multiCaching = function(caches, options) {
      * @param {function} cb
      */
     self.getAndPassUp = function(key, cb) {
-        getFromHighestPriorityCache(key, function(err, result, index) {
+        return getFromHighestPriorityCache(key, function(err, result, index) {
             if (err) {
-                if (typeof cb === 'function') {
+                if (cb) {
                     return cb(err);
-                } else {
-                    return cb.reject(err);
                 }
             }
 
-            if (typeof cb === 'function') {
+            if (cb) {
                 cb(err, result);
-            } else {
-                cb.resolve(result);
             }
 
             if (index) {
@@ -282,11 +280,7 @@ var multiCaching = function(caches, options) {
             options = {};
         }
 
-        var defer = Promise.defer();
-
-        getFromHighestPriorityCache(key, options, cb || defer);
-
-        return defer.promise;
+        return getFromHighestPriorityCache(key, options, cb);
     };
 
     /**

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -27,6 +27,8 @@ var memoryStore = function(args) {
         lruCache.set(key, value, maxAge);
         if (cb) {
             process.nextTick(cb);
+        } else {
+            return Promise.resolve(value);
         }
     };
 
@@ -35,6 +37,7 @@ var memoryStore = function(args) {
             cb = options;
         }
         var value = lruCache.get(key);
+
         if (cb) {
             process.nextTick(function() {
                 cb(null, value);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.3.0",
+    "es6-promise": "^3.0.2",
     "istanbul": "^0.2.11",
     "jscs": "^1.9.0",
     "jsdoc": "^3.3.0",

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -673,6 +673,62 @@ describe("caching", function() {
                 });
             });
         });
+
+        describe("using native promises", function() {
+            beforeEach(function() {
+                cache = caching({
+                    store: 'memory',
+                    max: 50,
+                    ttl: 5 * 60
+                });
+            });
+
+            it("should be able to chain with simple promise", function(done) {
+                cache.wrap('key', function() {
+                    return 'OK';
+                })
+                .then(function(res) {
+                    assert.equal(res, 'OK');
+                    done();
+                });
+            });
+
+            it("should be able to chain with cache function as a promise", function(done) {
+                cache.wrap('key', function() {
+                    return new Promise(function(resolve) {
+                        resolve('OK');
+                    });
+                })
+                .then(function(res) {
+                    assert.equal(res, 'OK');
+                    done();
+                });
+            });
+
+            it("should be able to catch errors in cache function as a promise", function(done) {
+                cache.wrap('key', function() {
+                    return new Promise(function(resolve, reject) {
+                        reject('NOK');
+                    });
+                })
+                .then(function() {
+                    done(new Error('It should not call then since there is an error in the cache function!'));
+                })
+                .catch(function() {
+                    done();
+                });
+            });
+
+            it("should be able to chain with non-cacheable value", function(done) {
+                cache.wrap('key', function() {
+                    return;
+                })
+                .then(function(res) {
+                    assert.equal(res, undefined);
+                    done();
+                });
+            });
+        });
     });
 
     describe("instantiating with no store passed in", function() {

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -970,6 +970,70 @@ describe("multiCaching", function() {
                 });
             });
         });
+
+        describe("using native promises", function() {
+            beforeEach(function() {
+                multiCache = multiCaching([memoryCache, memoryCache3]);
+            });
+
+            it("should be able to chain with simple promise", function(done) {
+                multiCache.wrap('key', function() {
+                    return 'OK';
+                })
+                .then(function(res) {
+                    assert.equal(res, 'OK');
+                    done();
+                });
+            });
+
+            it("should be able to chain with cache function as a promise", function(done) {
+                multiCache.wrap('key', function() {
+                    return new Promise(function(resolve) {
+                        resolve('OK');
+                    });
+                })
+                .then(function(res) {
+                    assert.equal(res, 'OK');
+                    done();
+                });
+            });
+
+            it("should be able to catch errors in cache function as a promise", function(done) {
+                multiCache.wrap('key', function() {
+                    return new Promise(function(resolve, reject) {
+                        reject('NOK');
+                    });
+                })
+                .then(function() {
+                    done(new Error('It should not call then since there is an error in the cache function!'));
+                })
+                .catch(function() {
+                    done();
+                });
+            });
+
+            it("should be able to catch a throw in cache function as a promise", function(done) {
+                multiCache.wrap('key', function() {
+                    throw 'NOK';
+                })
+                .then(function() {
+                    done(new Error('It should not call then since there is an error in the cache function!'));
+                })
+                .catch(function() {
+                    done();
+                });
+            });
+
+            it("should be able to chain with non-cacheable value", function(done) {
+                multiCache.wrap('key', function() {
+                    return;
+                })
+                .then(function(res) {
+                    assert.equal(res, undefined);
+                    done();
+                });
+            });
+        });
     });
 
     context("when instantiated with a non-Array 'caches' arg", function() {

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -289,6 +289,17 @@ describe("multiCaching", function() {
                     });
                 });
             });
+
+            it("gets data from first cache that has it using promises", function(done) {
+                memoryCache3.set(key, value)
+                .then(function() {
+                    return multiCache.getAndPassUp(key);
+                })
+                .then(function(result) {
+                    assert.equal(result, value);
+                    done();
+                });
+            });
         });
 
         describe("when value is not found in any cache", function() {
@@ -351,6 +362,22 @@ describe("multiCaching", function() {
                         });
                     });
                 });
+            });
+
+            it("checks to see if higher levels have item using promises", function(done) {
+                memoryCache3.set(key, value)
+                .then(function() {
+                    return multiCache.getAndPassUp(key);
+                })
+                .then(function(result) {
+                    assert.equal(result, value);
+                })
+                .then(function() {
+                    process.nextTick(function() {
+                        assert.equal(memoryCache.get(key), value);
+                    });
+                })
+                .then(done);
             });
 
             context("when a cache store calls back with an error", function() {

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -181,6 +181,19 @@ describe("multiCaching", function() {
                     });
                 });
             });
+
+            describe('using promises', function() {
+                it('should return a promise and resolve it', function(done) {
+                    memoryCache3.set(key, value)
+                    .then(function() {
+                        return multiCache.get(key);
+                    })
+                    .then(function(result) {
+                        assert.equal(result, value);
+                    })
+                    .then(done);
+                });
+            });
         });
 
         describe("del()", function() {

--- a/test/run.js
+++ b/test/run.js
@@ -6,6 +6,10 @@ var Mocha = require('mocha');
 var optimist = require('optimist');
 var walkDir = require('./support').walkDir;
 
+if (typeof Promise === "undefined") {
+    global.Promise = require('es6-promise').Promise;
+}
+
 var argv = optimist
 .usage("Usage: $0 -t [types] --reporter [reporter] --timeout [timeout]")['default'](
     {types: 'unit,functional', reporter: 'spec', timeout: 6000})


### PR DESCRIPTION
To handle #24 

There is the promise support WIP branch to make the cache manager handle promises.

I have some issues on the existing cache providers, and for tests. Right now only wrap (simple cache and multi cache) and get/set (multi cache) are implemented.

The issue with single store cache is that cache-manager is directly binded to the underlying methods, and to add promise support in get I need to change the method usage and add a breaking change, that I would like to avoid.

Some more tests to be added (100% on wrap, drop to 97% on get/set ATM)