### PR TITLE
removing domain error catching from caching/multi-caching

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -1,6 +1,5 @@
 /** @module cacheManager/caching */
 /*jshint maxcomplexity:15*/
-var domain = require('domain');
 var CallbackFiller = require('./callback_filler');
 
 /**
@@ -92,7 +91,7 @@ var caching = function(args) {
         }
 
         var hasKey = callbackFiller.has(key);
-        callbackFiller.add(key, {cb: cb, domain: process.domain});
+        callbackFiller.add(key, {cb: cb});
         if (hasKey) { return; }
 
         self.store.get(key, options, function(err, result) {
@@ -101,12 +100,7 @@ var caching = function(args) {
             } else if (self._isCacheableValue(result)) {
                 callbackFiller.fill(key, null, result);
             } else {
-                domain
-                .create()
-                .on('error', function(err) {
-                    callbackFiller.fill(key, err);
-                })
-                .bind(work)(function(err, data) {
+                work(function(err, data) {
                     if (err) {
                         callbackFiller.fill(key, err);
                         return;

--- a/lib/callback_filler.js
+++ b/lib/callback_filler.js
@@ -3,10 +3,8 @@ function CallbackFiller() {
 }
 
 CallbackFiller.prototype.fill = function(key, err, data) {
-    var self = this;
-
-    var waiting = self.queues[key];
-    delete self.queues[key];
+    var waiting = this.queues[key];
+    delete this.queues[key];
 
     waiting.forEach(function(task) {
         (task.cb)(err, data);

--- a/lib/callback_filler.js
+++ b/lib/callback_filler.js
@@ -1,5 +1,3 @@
-var domain = require('domain');
-
 function CallbackFiller() {
     this.queues = {};
 }
@@ -11,8 +9,7 @@ CallbackFiller.prototype.fill = function(key, err, data) {
     delete self.queues[key];
 
     waiting.forEach(function(task) {
-        var taskDomain = task.domain || domain.create();
-        taskDomain.bind(task.cb)(err, data);
+        (task.cb)(err, data);
     });
 };
 

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -1,6 +1,5 @@
 /** @module cacheManager/multiCaching */
 var async = require('async');
-var domain = require('domain');
 var CallbackFiller = require('./callback_filler');
 
 /**
@@ -218,7 +217,7 @@ var multiCaching = function(caches, options) {
         }
 
         var hasKey = callbackFiller.has(key);
-        callbackFiller.add(key, {cb: cb, domain: process.domain});
+        callbackFiller.add(key, {cb: cb});
         if (hasKey) { return; }
 
         getFromHighestPriorityCache(key, function(err, result, index) {
@@ -232,14 +231,7 @@ var multiCaching = function(caches, options) {
                     callbackFiller.fill(key, err, result);
                 });
             } else {
-                domain
-                .create()
-                .on('error', function(err) {
-                    if (callbackFiller.has(key)) {
-                        callbackFiller.fill(key, err);
-                    }
-                })
-                .bind(work)(function(err, data) {
+                work(function(err, data) {
                     if (err) {
                         return callbackFiller.fill(key, err);
                     }

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -529,12 +529,20 @@ describe("caching", function() {
                     fakeError = new Error(support.random.string());
                 });
 
-                it("bubbles up that error", function(done) {
+                it("does not catch the error", function(done) {
+                    var originalExceptionHandler = process.listeners('uncaughtException').pop();
+                    process.removeListener('uncaughtException', originalExceptionHandler);
+
+                    process.once('uncaughtException', function(err) {
+                        process.on('uncaughtException', originalExceptionHandler);
+                        assert.ok(err);
+                        done();
+                    });
+
                     cache.wrap(key, function() {
                         throw fakeError;
-                    }, function(err) {
-                        assert.equal(err, fakeError);
-                        done();
+                    }, function() {
+                        done(new Error('Should not have caught error'));
                     });
                 });
             });

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -923,12 +923,20 @@ describe("multiCaching", function() {
                     fakeError = new Error(support.random.string());
                 });
 
-                it("bubbles up that error", function(done) {
+                it("does not catch the error", function(done) {
+                    var originalExceptionHandler = process.listeners('uncaughtException').pop();
+                    process.removeListener('uncaughtException', originalExceptionHandler);
+
+                    process.once('uncaughtException', function(err) {
+                        process.on('uncaughtException', originalExceptionHandler);
+                        assert.ok(err);
+                        done();
+                    });
+
                     multiCache.wrap(key, function() {
                         throw fakeError;
-                    }, ttl, function(err) {
-                        assert.equal(err, fakeError);
-                        done();
+                    }, function() {
+                        done(new Error('Should not have caught error'));
                     });
                 });
             });


### PR DESCRIPTION
Removes `domain` error handling (see #38).