### PR TITLE
Triggering callback in wrap after it was queued

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -107,7 +107,8 @@ var caching = function(args) {
                     }
 
                     if (!self._isCacheableValue(data)) {
-                        return cb();
+                        callbackFiller.fill(key, null, data);
+                        return;
                     }
 
                     self.store.set(key, data, options, function(err) {

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -688,6 +688,27 @@ describe("caching", function() {
                     });
                 });
             });
+
+            context("when wrapped function returns a non cacheable value once", function() {
+                it("second call to 'wrap' triggers the callback", function(done) {
+                    var key = support.random.string();
+
+                    // 1.
+                    cache.wrap(key, function(cb) {
+                        cb(null, undefined);
+                    }, function(err, result) {
+                        assert.equal(result, undefined);
+                    });
+
+                    // 2.
+                    cache.wrap(key, function(cb) {
+                        cb(null, undefined);
+                    }, function(err, result) {
+                        assert.equal(result, undefined);
+                        done();
+                    });
+                });
+            });
         });
 
         describe("when called multiple times in parallel with same key", function() {


### PR DESCRIPTION
Just noticed that callback in `wrap` method never gets triggered second time if a non cacheable value is returned. This pull request fixes it.