### PR TITLE
Add hazelcast store to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ See the [Express.js cache-manager example app](https://github.com/BryanDonovan/n
 
 * [node-cache-manager-fs-binary](https://github.com/sheershoff/node-cache-manager-fs-binary)
 
+* [node-cache-manager-hazelcast](https://github.com/marudor/node-cache-manager-hazelcast)
+
 ## Overview
 
 First, it includes a `wrap` function that lets you wrap any function in cache.


### PR DESCRIPTION
I've added my store for hazelcast (https://github.com/marudor/node-cache-manager-hazelcast) to the README.