### PR TITLE
Feature/dynamic cache ttl

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -113,6 +113,10 @@ var caching = function(args) {
                         return;
                     }
 
+                    if(typeof options.computeTTL === 'function'){
+                      options.ttl = options.computeTTL(data);
+                    }
+
                     self.store.set(key, data, options, function(err) {
                         if (err && (!self.ignoreCacheErrors)) {
                             callbackFiller.fill(key, err);

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -115,6 +115,7 @@ var caching = function(args) {
 
                     if (typeof options.computeTTL === 'function') {
                         options.ttl = options.computeTTL(data);
+                        delete options.computeTTL;
                     }
 
                     self.store.set(key, data, options, function(err) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -113,8 +113,8 @@ var caching = function(args) {
                         return;
                     }
 
-                    if(typeof options.computeTTL === 'function'){
-                      options.ttl = options.computeTTL(data);
+                    if (typeof options.computeTTL === 'function') {
+                        options.ttl = options.computeTTL(data);
                     }
 
                     self.store.set(key, data, options, function(err) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -113,9 +113,9 @@ var caching = function(args) {
                         return;
                     }
 
-                    if (options && typeof options.computeTTL === 'function') {
-                        options.ttl = options.computeTTL(data);
-                        delete options.computeTTL;
+                    if (options && typeof options.computeTtl === 'function') {
+                        options.ttl = options.computeTtl(data);
+                        delete options.computeTtl;
                     }
 
                     self.store.set(key, data, options, function(err) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -113,9 +113,8 @@ var caching = function(args) {
                         return;
                     }
 
-                    if (options && typeof options.computeTtl === 'function') {
-                        options.ttl = options.computeTtl(data);
-                        delete options.computeTtl;
+                    if (options && typeof options.ttl === 'function') {
+                        options.ttl = options.ttl(data);
                     }
 
                     self.store.set(key, data, options, function(err) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -113,7 +113,7 @@ var caching = function(args) {
                         return;
                     }
 
-                    if (typeof options.computeTTL === 'function') {
+                    if (options && typeof options.computeTTL === 'function') {
                         options.ttl = options.computeTTL(data);
                         delete options.computeTTL;
                     }

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -369,9 +369,9 @@ describe("caching", function() {
                     memoryStoreStub.set.restore();
                 });
 
-                it("when a computeTTL function is passed in", function(done) {
+                it("when a computeTtl function is passed in", function(done) {
                     opts = {
-                        computeTTL: function(widget) {
+                        computeTtl: function(widget) {
                             assert.deepEqual(widget, {name: name});
                             return 0.2;
                         }

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -360,7 +360,7 @@ describe("caching", function() {
                 });
             });
 
-            context("compute ttl", function() {
+            context("ttl function", function() {
                 beforeEach(function() {
                     sinon.spy(memoryStoreStub, 'set');
                 });
@@ -369,9 +369,9 @@ describe("caching", function() {
                     memoryStoreStub.set.restore();
                 });
 
-                it("when a computeTtl function is passed in", function(done) {
+                it("when a ttl function is passed in", function(done) {
                     opts = {
-                        computeTtl: function(widget) {
+                        ttl: function(widget) {
                             assert.deepEqual(widget, {name: name});
                             return 0.2;
                         }

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -360,6 +360,33 @@ describe("caching", function() {
                 });
             });
 
+            context("compute ttl", function() {
+                beforeEach(function() {
+                    sinon.spy(memoryStoreStub, 'set');
+                });
+
+                afterEach(function() {
+                    memoryStoreStub.set.restore();
+                });
+
+                it("when a computeTTL function is passed in", function(done) {
+                    opts = {
+                        computeTTL: function(widget) {
+                            assert.deepEqual(widget, {name: name});
+                            return 0.2;
+                        }
+                    };
+                    cache.wrap(key, function(cb) {
+                        methods.getWidget(name, cb);
+                    }, opts, function(err, widget) {
+                        checkErr(err);
+                        assert.deepEqual(widget, {name: name});
+                        sinon.assert.calledWith(memoryStoreStub.set, key, {name: name}, {ttl: 0.2});
+                        done();
+                    });
+                });
+            });
+
             context("when result is already cached", function() {
                 function getCachedWidget(name, cb) {
                     cache.wrap(key, function(cacheCb) {


### PR DESCRIPTION
Allow users to compute TTL based on the wrapped function result data (instead a fixed value).
Needed this for a simple case of getting values back from an API, with values having an expiration date.

Usage : 

```
myCache.wrap(KEY, function(){
    return dataPromise;
  }, {
    computeTTL: function(data){
        if(isSoon(data.endOfLife)){
            return 600;
        }
        return 6000;
    }
  })
```
