### PR TITLE
Update dependency es6-promise to version 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.3.0",
-    "es6-promise": "^3.0.2",
+    "es6-promise": "4.0.5",
     "istanbul": "0.4.2",
     "jscs": "2.11.0",
     "jsdoc": "3.3.0",


### PR DESCRIPTION
This Pull Request updates dependency es6-promise from version ^3.0.2 to 4.0.5

### Changelog
4.0.5 / 2016-10-03
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * release v4.0.5
  * Merge pull request [#243](https://github.com/stefanpenner/es6-promise/issues/243) from wKovacs64/fix-auto-again
    Fix auto.js for Node &lt; 4 compatibility
  * Fix auto.js for Node &lt; 4 compatibility

4.0.4 / 2016-10-02
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * release v4.0.4
  * Merge pull request [#241](https://github.com/stefanpenner/es6-promise/issues/241) from ThomasConner/master
    Only use vertxNext() when it is not undefined
  * Update the dist files
  * Only use vertxNext() when it is not undefined

4.0.3 / 2016-09-27
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * release v4.0.3
  * Fix download links in README
  * Merge pull request [#240](https://github.com/stefanpenner/es6-promise/issues/240) from stefanpenner/greenkeeper-mocha-3.1.0
    Update mocha to version 3.1.0 🚀
  * chore(package): update mocha to version 3.1.0
    https://greenkeeper.io/

4.0.2 / 2016-09-26
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * release v4.0.2

4.0.1 / 2016-09-26
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * release v4.0.1

4.0.0 / 2016-09-26
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * Merge pull request [#230](https://github.com/stefanpenner/es6-promise/issues/230) from stefanpenner/4.x
    Provide separate auto-polyfill version of this module
  * release v4.0.0
  * update README: re auto polyfil
  * build output
  * Provide separate auto-polyfill version of this module
    This commit provides a mechanism for users to load a version of this
    module which automatically installs the polyfill, separately from the
    default non-automatic version, as outlined in
    https://github.com/jakearchibald/es6-promise/pull/126#issuecomment-120542090
    It uses require(&#x27;es6-promise/auto&#x27;) instead of
    require(&#x27;es6-promise/polyfil&#x27;) so that it does not directly conflict
    with the es-shim-api API Contract[1], in case support is later added.
    In addition to the Node/Browserify file, a UMD file which triggers
    automatic polyfill installation is also provided.
    Fixes: [#140](https://github.com/stefanpenner/es6-promise/issues/140)
    Alternative-to: [#126](https://github.com/stefanpenner/es6-promise/issues/126)
    1.  https://github.com/es-shims/es-shim-api#api-contract
    Signed-off-by: Kevin Locke &lt;kevin@kevinlocke.name&gt;
  * v3.3.1 dist