### PR TITLE
Update dependency jsdoc to version 3.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "es6-promise": "^3.0.2",
     "istanbul": "0.4.2",
     "jscs": "2.11.0",
-    "jsdoc": "3.3.0",
+    "jsdoc": "3.4.3",
     "jshint": "2.9.1",
     "mocha": "2.4.5",
     "optimist": "0.6.1",


### PR DESCRIPTION
This Pull Request updates dependency jsdoc from version 3.3.0 to 3.4.3

### Changelog
3.4.3 / 2016-11-09
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.4.3 changelog
  * clean up LICENSE file
    We no longer vendor most of these packages, so they don’t need to be listed in the LICENSE file.

3.4.2 / 2016-10-03
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * changelog for 3.4.2
  * Merge pull request [#1270](https://github.com/jsdoc3/jsdoc/issues/1270) from chrisrecher/dependency-removal
    Remove dependence on fs-extra.
  * Remove dependence on fs-extra.
  * handle exported ES2015 classes correctly ([#1137](https://github.com/jsdoc3/jsdoc/issues/1137))
  * remove unused regexp
  * upgrade Espree ([#1258](https://github.com/jsdoc3/jsdoc/issues/1258))
  * manually revert fix for [#1081](https://github.com/jsdoc3/jsdoc/issues/1081) (6be9dac616549ce226e4c0064876c7cb3b64fe25)
    This fix caused [#1259](https://github.com/jsdoc3/jsdoc/issues/1259).

3.4.1 / 2016-09-08
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * changelog for 3.4.1
  * update dependencies
  * Merge pull request [#1255](https://github.com/jsdoc3/jsdoc/issues/1255) from lextiz/patch-2
    Fetch taffydb from npm registry, fixes [#961](https://github.com/jsdoc3/jsdoc/issues/961)
  * Fetch taffydb from npm registry
  * bump revision
  * upgrade marked ([#1200](https://github.com/jsdoc3/jsdoc/issues/1200))
  * test with current Node.js versions
  * Merge pull request [#1220](https://github.com/jsdoc3/jsdoc/issues/1220) from clenemt/master
    Add example for docdash
  * Update dependencies
  * Merge branch &#x27;dep-up-minor&#x27; of https://github.com/bjornharrtell/jsdoc into bjornharrtell-dep-up-minor
  * fix outdated link to Underscore.js ([#1241](https://github.com/jsdoc3/jsdoc/issues/1241))
  * Add example for docdash
  * use latest Catharsis
  * Replace wrench with fs-extra
  * Update bluebird major version
  * Update gulp-eslint and minor style fixes to adapt to new eslint version
  * Upgrade dependencies within minor levels
  * Merge pull request [#1131](https://github.com/jsdoc3/jsdoc/issues/1131) from mlucool/master
    Update README.md to include gulp task
  * Merge pull request [#1159](https://github.com/jsdoc3/jsdoc/issues/1159) from kevinoid/allow-unknown-tags-array
    Support an Array of tags titles in allowUnknownTags
  * Merge pull request [#1147](https://github.com/jsdoc3/jsdoc/issues/1147) from pra85/2016
    Update license year range to 2016
  * Merge pull request [#1160](https://github.com/jsdoc3/jsdoc/issues/1160) from kevinoid/silent-template
    Create silent template
  * Merge pull request [#1166](https://github.com/jsdoc3/jsdoc/issues/1166) from clenemt/master
    Add docdash to README.md
  * Add docdash to available templates
    If you are ever interested in another template you can merge this in :)
  * Create silent template
    This commit creates a template named &#x60;silent&#x60; which outputs nothing at
    all.  As discussed in the &#x60;README.md&#x60;, this can be useful when running
    JSDoc as a linter to check for syntax errors or unknown tags.  It may
    also be useful for testing or benchmarking.
    The same effect can be achieved using the haruki template and
    redirecting the output to /dev/null, but this has a few downsides:
    * It is non-obvious.
    * It is difficult to do in scripts which must run in bash and cmd.exe
    (like npm scripts).
    * It is slower due to the unnecessary formatting work and output
    syscalls.
    This template could be distributed as a third-party template, but given
    the tiny code size, broad applicability, and potential usefulness for
    tests, it makes sense to include it officially.
    Signed-off-by: Kevin Locke &lt;kevin@kevinlocke.name&gt;
  * Support an Array of tags titles in allowUnknownTags
    This commit adds support for specifying an Array of tags which are
    unknown to JSDoc, but allowed without error.  It provides a more
    granular way to disable such errors while retaining the benefits of
    catching errant tags (e.g. typos).
    The intended use case is catching errant tags when using additional
    tools which support tags not recognized by JSDoc (e.g. Closure Compiler
    and the tags discussed in [#605](https://github.com/jsdoc3/jsdoc/issues/605)).
    Signed-off-by: Kevin Locke &lt;kevin@kevinlocke.name&gt;
  * Remove dead code for allowUnknownTags checking
    When tagDef is falsey the previous if block is entered and the function
    always returns.  Therefore, this code block can never be entered.  If it
    could, it would log the same error as above.  Remove it.
    Signed-off-by: Kevin Locke &lt;kevin@kevinlocke.name&gt;
  * Update license
  * autodetect défault and repeatable parameters in ES2015 methods ([#1144](https://github.com/jsdoc3/jsdoc/issues/1144))
  * Merge pull request [#1139](https://github.com/jsdoc3/jsdoc/issues/1139) from algolia/fix/lint-cli-double-quotes
    fix(lint): fix cli quotes
  * Merge pull request [#1140](https://github.com/jsdoc3/jsdoc/issues/1140) from algolia/fix/avoid-astnode.js-test-skip
    test(astnode.js): avoid skipping tests having node.js inside
  * Merge pull request [#1141](https://github.com/jsdoc3/jsdoc/issues/1141) from algolia/fix/handle-object-spread-operator
    fix(object spread): support experimental object spread
  * fix(object spread): support experimental object spread
    As per https://github.com/sebmarkbage/ecmascript-rest-spread
    This was badly failing previously.
    Any insights/comments welcomed!
  * test(astnode.js): avoid skipping tests having node.js inside
    This commit makes the test suite run test/specs/jsdoc/src/astnode.js
    It was previously skipped because of the runtime being node and
    astnode.js containing &quot;node&quot;..
    I even wonder if its still relevant to try to support different
    runtime, but that&#x27;s for another PR I guess.
  * fix(lint): fix cli quotes
    linting was failing
  * Update README.md to include gulp task
  * Merge pull request [#1122](https://github.com/jsdoc3/jsdoc/issues/1122) from lukeapage/patch-1
    Change URL for where docstrap now lives
  * use appropriate styling for all tables ([#1064](https://github.com/jsdoc3/jsdoc/issues/1064))
  * add test for the Markdown fix in acc47fdfd19c53f8836e6ec5ade939c94c23013a
  * Merge pull request [#1036](https://github.com/jsdoc3/jsdoc/issues/1036) from Oblongmana/fix/markdown-breaks-namepaths-with-special-characters
    Fix markdown breaking namepaths w/special chars
  * differentiate CSS for h2 and h3 elements ([#1108](https://github.com/jsdoc3/jsdoc/issues/1108))
  * fixing [#1081](https://github.com/jsdoc3/jsdoc/issues/1081):
    - tightened-up detection of the correct path for the plugins by checking if the plugin file *itself* actually exists in the given path; it&#x27;s done this way to cope with scenarios where JSDoc is executed in another project&#x27;s working directory where *that* project has plugins of itself in a similar directory structure (&#x60;plugins/*&#x60;).
    We DO NOT change the search path used by JSDoc.
    - ditto for templates: we know that a template MUST have a &#x60;publish.js&#x60; file at least, so we go and check if that one exists at the location where we would otherwise have assumed it does.
  * better docs
  * fix multiple naming issues with members of a class that is the default export ([#1120](https://github.com/jsdoc3/jsdoc/issues/1120))
  * Change URL for where docstrap now lives
  * refactor
  * bump version
  * correctly handle classes that are the default export ([#1113](https://github.com/jsdoc3/jsdoc/issues/1113))
  * prevent crash when exporting an anonymous class ([#1113](https://github.com/jsdoc3/jsdoc/issues/1113))
  * cleanup

3.4.0 / 2015-11-17
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.4.0
  * add 3.4.0 changelog
  * bump revision
  * Merge pull request [#1106](https://github.com/jsdoc3/jsdoc/issues/1106) from tschaub/four
    Remove Mozilla Rhino support
  * Merge pull request [#1082](https://github.com/jsdoc3/jsdoc/issues/1082) from nicksay/quick-fix-for-1070
    Prevent output from being cut off in Node 4
  * Prevent output from being cut off in Node 4
    This is a quick fix for truncated output in Node 4 by only calling
    &#x60;process.exit&#x60; for errors.
    Closes [#1070](https://github.com/jsdoc3/jsdoc/issues/1070)
  * Remove Rhino support
  * Ignore node_modules
  * Remove node_modules
  * Merge pull request [#1063](https://github.com/jsdoc3/jsdoc/issues/1063) from rainum/hotfix/haruki-default-values
    fix displaying of falsy default values in haruki template
  * Merge pull request [#1084](https://github.com/jsdoc3/jsdoc/issues/1084) from nicksay/lint-space-after-keywords
    Clean up space-after-keywords lint violations
  * prevent crash on &#x60;JSXAttribute&#x60; nodes with no value ([#1085](https://github.com/jsdoc3/jsdoc/issues/1085))
  * prevent crash on &#x60;ExperimentalRestProperty&#x60; nodes ([#1091](https://github.com/jsdoc3/jsdoc/issues/1091))
  * Clean up space-after-keywords lint violations
    This eliminates the following when running &#x60;gulp lint&#x60;:
    &gt; error  Keyword &quot;catch&quot; must be followed by whitespace
    Closes [#1083](https://github.com/jsdoc3/jsdoc/issues/1083)

3.3.3 / 2015-09-22
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * update changelog for 3.3.3
  * fix displaying of falsy default values in haruki template
  * Merge pull request [#1062](https://github.com/jsdoc3/jsdoc/issues/1062) from mcarroll1283/walker-typo
    Fix typo in JSXMemberExpresson walker
  * Fix typo in JSXMemberExpresson walker
  * support arrow function expressions ([#555](https://github.com/jsdoc3/jsdoc/issues/555))
  * look for JSX files by default ([#1001](https://github.com/jsdoc3/jsdoc/issues/1001))
  * whitespace
  * use the correct longname for properties documented in instance methods ([#1011](https://github.com/jsdoc3/jsdoc/issues/1011))
    Fixes a regression caused by 65f307322ac64d965694dca8f82bf98f08a1e2e4.
  * Merge pull request [#986](https://github.com/jsdoc3/jsdoc/issues/986) from snoack/master
    Added option to use longnames in navigation to default template
  * add JSX support ([#1001](https://github.com/jsdoc3/jsdoc/issues/1001))
  * update gulp-eslint; delint
  * Added option to use longnames in navigation to default template
  * Merge pull request [#1032](https://github.com/jsdoc3/jsdoc/issues/1032) from bobylito/master
    Make the markdown parser able to generate anchors for headings
  * Make the markdown parser able to generate anchors for headings
    It uses the following configuration key in the markdown
    section : idInHeadings.
    If set to true it will make the headings generated in the markdown have
    id&#x27;s like on github.
  * Merge pull request [#1044](https://github.com/jsdoc3/jsdoc/issues/1044) from dandv/patch-1
    Direct link to Travis build image
  * Direct link to Travis build image
  * update dependencies
  * Merge pull request [#1013](https://github.com/jsdoc3/jsdoc/issues/1013) from TimOgilvy/patch-1
    Remove whitespace from around object name
  * prevent infinite loop that can be caused by double module definitions ([#975](https://github.com/jsdoc3/jsdoc/issues/975))
  * prevent crash when a FunctionDeclaration node lacks an &#x60;id&#x60; property ([#1030](https://github.com/jsdoc3/jsdoc/issues/1030))
  * Fix markdown breaking namepaths w/special chars
  * attach comments to default/rest parameters ([#1025](https://github.com/jsdoc3/jsdoc/issues/1025))
  * doc cleanup
  * bump revision

3.3.2 / 2015-06-13
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * update changelog for 3.3.2
  * upgrade Espree, and update code to reflect breaking changes in Espree ([#977](https://github.com/jsdoc3/jsdoc/issues/977))