### PR TITLE
Update dependency jscs to version 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coveralls": "^2.3.0",
     "es6-promise": "^3.0.2",
     "istanbul": "0.4.2",
-    "jscs": "2.11.0",
+    "jscs": "3.0.7",
     "jsdoc": "3.3.0",
     "jshint": "2.9.1",
     "mocha": "2.4.5",


### PR DESCRIPTION
This Pull Request updates dependency jscs from version 2.11.0 to 3.0.7

### Changelog
3.0.7 / 2016-07-13
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.7
  * Misc: add changelog for 3.0.7
  * validateParameterSeparator: notice class methods
    Fixes [#2289](https://github.com/jscs-dev/node-jscs/issues/2289)

3.0.6 / 2016-07-01
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.6
  * Misc: add 3.0.6 changelog
  * requireDollarBeforejQueryAssignment: do not blow up on reset parameter
    Fixes [#2285](https://github.com/jscs-dev/node-jscs/issues/2285)
  * Misc: explicitly use latest CST version
  * Misc: fix typo in the changelog
  * Misc: bump CST version to 0.4.2

3.0.5 / 2016-06-21
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.5
  * Misc: add 3.0.5 changelog
  * Configuration: move hasCorrectExtension to more appropriate place
  * Configuration: Do not set default options if preset is set
    Ref [#2276](https://github.com/jscs-dev/node-jscs/issues/2276)
    Fixes [#2275](https://github.com/jscs-dev/node-jscs/issues/2275)
  * Misc: bump CST version to 0.4.0
    Fixes [#2270](https://github.com/jscs-dev/node-jscs/issues/2270)
  * Docs: remove yandex preset from overview
  * Docs: add intro delimiter to readme
  * Misc: use correct headers in changelog
  * Misc: correct changelog auto-replace result
  * Misc: correct changelog jscs version
  * Misc: changelog should be consistent

3.0.4 / 2016-06-03
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.4
  * Misc: add 3.0.4 changelog
  * Tests: do not run integration tests
    Ref [#2253](https://github.com/jscs-dev/node-jscs/issues/2253)
    Ref cst/cst[#113](https://github.com/jscs-dev/node-jscs/issues/113)
  * maximumLineLength: correctly position error for comment nodes
    Fixes [#2233](https://github.com/jscs-dev/node-jscs/issues/2233)
  * disallowUnusedParams: notice AssignmentPattern nodes
    Fixes [#2254](https://github.com/jscs-dev/node-jscs/issues/2254)
  * Docs: Fix small typo in require-early-return ([#2259](https://github.com/jscs-dev/node-jscs/issues/2259))
  * Build: update cst to 0.3.0
  * disallowPaddingNewlinesBeforeKeywords: should not ignore comments
    Fixes [#2237](https://github.com/jscs-dev/node-jscs/issues/2237)
  * requireCurlyBraces: small docs corrections
  * Misc: make linters happy
  * Misc: add node 6 to travis
  * Misc: do not modify CST in check mode ([#2252](https://github.com/jscs-dev/node-jscs/issues/2252))
    * Slightly changes token-assert API by providing result of the check
    with return values
    * Apply fixes only in fix mode
    * Modify couple rules to adjust to new strategy
    * Make &quot;fixed&quot; property of the Error instance consistent
    * Introduce &quot;fix&quot; property of the Error class
    * Divide fix behaviour on &quot;common&quot; and &quot;specific&quot; actions
    Consequently should speed up linting
    Fixes [#2244](https://github.com/jscs-dev/node-jscs/issues/2244)
  * Misc: remove rules &quot;grouping&quot;
  * Misc: bump cst version
    Fixes [#2240](https://github.com/jscs-dev/node-jscs/issues/2240)
  * Tests: remove mocha &#x60;.only&#x60; call
  * disallowQuotedKeysInObjects: ignore spread properties
    Fixes [#2249](https://github.com/jscs-dev/node-jscs/issues/2249)
  * Errors: add ugly exception for &#x60;validateQuoteMarks&#x60; of position calc
    Fixes [#2223](https://github.com/jscs-dev/node-jscs/issues/2223)
  * disallowObjectKeysOnNewLine: correct error message
    Fixes [#2229](https://github.com/jscs-dev/node-jscs/issues/2229)
  * Errors: always add to &#x60;line&#x60; and &#x60;column&#x60; properties
    Ref [#2243](https://github.com/jscs-dev/node-jscs/issues/2243)
    Ref [#2219](https://github.com/jscs-dev/node-jscs/issues/2219)
  * requireObjectKeysOnNewLine: do not break on object methods
    Fixes [#2236](https://github.com/jscs-dev/node-jscs/issues/2236)
  * Docs: simplify readme a bit more
  * Docs: deprecation clean-up
    Fixes gh-2231
  * Fix: Last method throw in requireObjectKeysOnNewLine
    Fixes [#2224](https://github.com/jscs-dev/node-jscs/issues/2224)
    Closes gh-2227
  * Misc: parallelizing build on travis
  * Misc: Set higher timeout for config generator tests
  * add jscs+eslint info ([#2230](https://github.com/jscs-dev/node-jscs/issues/2230))

3.0.3 / 2016-04-16
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.3
  * Docs: 3.0.3 changelog [ci skip]
  * Misc: Make an exception for esnext/verbose since they are removed ([#2208](https://github.com/jscs-dev/node-jscs/issues/2208))
    Fixes [#2220](https://github.com/jscs-dev/node-jscs/issues/2220)
  * Revert &quot;Configuration: exclude nested node_modules by default&quot; ([#2222](https://github.com/jscs-dev/node-jscs/issues/2222))
    This reverts commit 908bd20654723eac98949f994710c9ea902fe671.

3.0.2 / 2016-04-15
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.2
  * Docs: add 3.0.1 and 3.0.2 changelog
  * Fix: Revert rule value deprecations ([#2217](https://github.com/jscs-dev/node-jscs/issues/2217))
    - Not necessary to remove this now since we are merging with ESLint - it should allow users to not have to change their config when upgrading to 3.0.
  * Docs: Update changelog [ci skip]
  * Docs: fix changelog [ci skip]
  * 3.0.1
  * [Fix] disallowUnusedVariables included function expressions

3.0.1 / 2016-04-14
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * Docs: use &quot;http&quot; protocol in changelog
    Fixes [#2214](https://github.com/jscs-dev/node-jscs/issues/2214)
  * Misc: remove leftover from the browser version

3.0.0 / 2016-04-14
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * 3.0.0
  * Misc: add 3.0.0 changelog
  * Tests: one last improvement to generator tests
  * Misc: make linters happy
  * Tests: remove unstable generator test and re-enable it
  * Tests: skip the generator tests
  * Docs: remove leftover of yandex preset
  * [Perf] Reduce location computations
  * [Fix] Parsing errors
  * [Fix] Keywords in identifiers
  * [Fix] Unskip generator tests
  * [Fix] Remaining style issues
  * [Fix] JsDoc plugin dep
  * [Fix] Error fixes
  * Preset: allow URLs inside comments for airbnb
    Make an exeption for URLs inside comments in maximumLineLength rule
    Ref airbnb/javascript[#819](https://github.com/jscs-dev/node-jscs/issues/819)
    Closes gh-2207
  * Misc: Bump cst version and re-enable integration tests
  * disallowUnusedVariables: adapt to cst 0.1.3
  * Misc: divide lint commands
  * New rule: disallowUnusedVariables
    Fixes [#2076](https://github.com/jscs-dev/node-jscs/issues/2076)
    Closes gh-2199
  * Misc: bump cst version
  * es5
  * fixup linting issues
  * fix cst url
  * [Perf] Remove JsFile.getFirstTokenOnLine
  * [Perf] Remove getLoc() in TokenAssert.indentation and requireAlignedMultilineParams
  * [Fix] Remove unused tokenBefore / noTokenBefore
  * [Perf] Remove getLoc from linesBetween() method
  * [Perf] Remove getNodeByRange
  * [Perf] Remove getRange() from token categorizer
  * validateAlignedFunctionParameters: use file#isOnTheSameLine if possible
  * [Perf] Remove getRange() from rules
  * disallowSpacesInConditionalExpression: do not use &#x60;getLoc&#x60; method
  * [Perf] Remove another getRange()
  * [Performance] Fix spaces between assert
  * requireCapitalizedComments: do not use &#x60;getLoc&#x60; method
  * disallowPaddingNewLinesAfterBlocks: don&#x27;t use &#x60;getLoc&#x60; method