### PR TITLE
Pin dependency coveralls to version 2.11.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lru-cache": "4.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.3.0",
+    "coveralls": "2.11.15",
     "es6-promise": "^3.0.2",
     "istanbul": "0.4.2",
     "jscs": "2.11.0",


### PR DESCRIPTION
This Pull Request updates dependency coveralls from version ^2.3.0 to 2.11.15

