### PR TITLE
Update dependency lru-cache to version 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.2",
-    "lru-cache": "4.0.0"
+    "lru-cache": "4.0.2"
   },
   "devDependencies": {
     "coveralls": "^2.3.0",


### PR DESCRIPTION
This Pull Request updates dependency lru-cache from version 4.0.0 to 4.0.2

### Changelog
4.0.2 / 2016-11-27
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * v4.0.2
  * update tap for speedy coverage
  * Unset Symbol after require.
    Fixes: https://github.com/isaacs/node-lru-cache/issues/96
  * Add installation instructions
    Since the repo is named &#x60;node-lru-cache&#x60;, I always forget and try that first. I&#x27;m assuming other people do the same thing!
  * fixed typo

4.0.1 / 2016-03-22
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * v4.0.1
  * ignore test coverage around Symbol capability test
  * Use package.json files array to limit package size
    Close [#73](https://github.com/isaacs/node-lru-cache/issues/73)
  * Fix .length documentation
  * use newer tap, require 100% test coverage for passing test