### PR TITLE
Update dependency jshint to version 2.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "istanbul": "0.4.2",
     "jscs": "2.11.0",
     "jsdoc": "3.3.0",
-    "jshint": "2.9.1",
+    "jshint": "2.9.4",
     "mocha": "2.4.5",
     "optimist": "0.6.1",
     "sinon": "1.17.3"


### PR DESCRIPTION
This Pull Request updates dependency jshint from version 2.9.1 to 2.9.4

### Changelog
2.9.4 / 2016-10-20
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * v2.9.4
  * [[CHORE]] Rename internal function
    The name &#x60;addEvalCode&#x60; more directly relates to relevant language in the
    ECMA262 specification.
  * [[FIX]] Do not duplicate reported warnings/errors
    Extend the testing infrastructure to recognize cases where identical
    warnings/errors are being reported, and address the areas of the code
    base that previously suffered from this problem.
  * [[FIX]] Report error for offending token value
    When a &quot;rest&quot; operator is not followed by the identifier, report the
    value of the unexpected token (not the &quot;rest&quot; operator itself).
  * [[FIX]] Offset line no.s of errors from eval code
  * [[CHORE]] Use project in latest state when linting ([#2860](https://github.com/jshint/jshint/issues/2860))
    * [[CHORE]] Use project in latest state when linting
    The latest stable version of JSHint revealed an erroneous configuration:
    when the &#x60;console&#x60; identifier is listed as a global variable, JSHint
    creates an internal &quot;label&quot; to track references to that binding. The
    local &#x60;console&#x60; variable in &#x60;jshint.js&#x60; shadows this global reference,
    meaning the global binding is never referenced.
    Lint the in-development codebase with the tool in its current state.
    Update the configuration to avoid the new (valid) warning.
    * fixup! [[CHORE]] Use project in latest state when linting
  * [[DOCS]] Improve warning message for W040 ([#3052](https://github.com/jshint/jshint/issues/3052))
    Expand the message to describe the rationale for the warning.
  * Enforce TDZ within initializer of lexical declaration (refactored) ([#2733](https://github.com/jshint/jshint/issues/2733))
    * [[FIX]] Enforce TDZ within initializer of lexical declaration
    Fixes [#2637](https://github.com/jshint/jshint/issues/2637)
    * [[FIX]] Enforce TDZ within class heritage definition
    * [[FIX]] Enforce TDZ within for in/of head
    Fixes gh-2693
    * [[CHORE]] Refactor var initialization tracking
    Conceptually, the initialization state of a given variable is a property
    of that variable. Model that relationship in the code organization by
    tracking variable initialization using a dedicated property on the
    representation of the variable itself. Beyond improving code clarity
    (the &quot;label&quot; objects remain the single source of truth for the state of
    each variable), this also reduces memory allocation costs (no new
    objects need to be created).
  * [[FIX]] Remove &#x60;null&#x60; value from &#x60;errors&#x60; array ([#3049](https://github.com/jshint/jshint/issues/3049))
    When reporting unrecoverable errors, JSHint would insert two elements
    into the global &#x60;errors&#x60; array: a descriptor for the error itself, and a
    &#x60;null&#x60; value. Because this behavior is undocumented and inconsistent, it
    is most likely the result of a programming error. Ensure that the
    &#x60;JSHINT.errors&#x60; collection contains only error descriptor.
  * [[DOCS]] Document inconsistent behavior ([#3048](https://github.com/jshint/jshint/issues/3048))
    As noted in the in-line comment, the current behavior is a result of a
    programming error. It may not be resolved outside of a major release
    because the project documentation does not describe the more desirable
    consistent behavior.
  * [[FIX]] Correct interpretation of ASI ([#3045](https://github.com/jshint/jshint/issues/3045))
    Previously, the following operators were incorrectly interpreted as
    &quot;infix&quot; operators:
    - &#x60;++&#x60;
    - &#x60;--&#x60;
    - &#x60;yield&#x60;
    The internal &#x60;isInfix&#x60; function tended to obscure this error because it
    identified &quot;infix&quot; tokens via a boolean logic expression that acted as a
    blacklist. This expression was difficult to understand and hostile to
    future extensions for new language features (because future tokens could
    be mistakenly implemented as &quot;infix&quot; operators).
    Update all &quot;infix&quot; operator token definitions to explicitly define the
    &#x60;infix&#x60; property, obviating the need for the internal &#x60;isInfix&#x60;
    function. Ensure that the aforementioned tokens are not interpreted as
    &quot;infix&quot; operators, This corrects the behavior of the internal
    &#x60;isEndOfExpr&#x60; function, which is appreciable when linting code that
    relies on automatic semicolon insertion.
  * [[FIX]] Avoid crashing on invalid input ([#3046](https://github.com/jshint/jshint/issues/3046))
    A recent extension to the &#x60;instanceof&#x60; operator introduced logic that
    performed property access on the result of parsing the operator&#x27;s
    right-hand expression operand. Because invalid code may not specify such
    an expression, this logic led to program crashes in response to the
    invalid syntax.
    Ensure that when the &#x60;instanceof&#x60; operator appears without a right-hand
    expression operand, JSHint reports a syntax error and exits gracefully.
  * Merge branch &#x27;patch-1&#x27; of https://github.com/thorn0/jshint into thorn0-patch-1
    # By Georgii Dolzhykov
    # Via thorn0
    * &#x27;patch-1&#x27; of https://github.com/thorn0/jshint:
    Fix the check if a file is ignored
    Signed-off-by: Rick Waldron &lt;waldron.rick@gmail.com&gt;
    Conflicts:
    tests/cli.js
  * Update README.md ([#2739](https://github.com/jshint/jshint/issues/2739))
    * Update README.md
    Fixing grammar, making words more streamline, adding that Google also uses JSHint
    * Update README.md
    Following caitp&#x27;s note: &quot;We&#x27;ve been moving away from code style conventions, might be better to leave that out&quot;
    * Update README.md
    Following line note and adding more edits
  * [[FIX]] Allow RegExp literal as &#x60;yield&#x60; operand ([#3011](https://github.com/jshint/jshint/issues/3011))
    Extend the lexer to recognize RegExp literals which immediately follow
    the &#x60;yield&#x60; operator.
  * Fix for gh-3013 ([#3016](https://github.com/jshint/jshint/issues/3016))
    * [[CHORE]] Remove &#x60;lex.start&#x60; method
    This method simply proxies &#x60;lex.nextLine&#x60; to scan a single line of the
    program. It is currently only used to scan the very first line of input,
    which is problematic for two reasons:
    1. Linting options have not yet been applied via the &#x60;assume&#x60; function,
    so linting options that effect the parser&#x27;s behavior are not honored
    for this first line (see the unit test corrected in this patch for an
    example)
    2. So-called &quot;checks&quot; for asynchronously-reported warnings on the first
    line cannot be associated with a token. This makes it impossible to
    issue warnings asynchronously for the first line.
    Because the &#x60;lex.token&#x60; method itself invokes &#x60;lex.nextLine&#x60;, these
    problems may be avoided by removing &#x60;lex.start&#x60; and deferring the
    invocation of &#x60;nextLine&#x60; until the first token is requested.
    * [[FIX]] Allow W100 to be ignored during lookahead
    Defer the reporting of warning W100 until parse time (using
    &#x60;triggerAsync&#x60;) so that it may be disabled via in-line directives even
    in contexts where a &quot;lookahead&quot; is taking place.
    * fixup! [[FIX]] Allow W100 to be ignored during lookahead
  * Rephrase message for W014 ([#3030](https://github.com/jshint/jshint/issues/3030))
    W014 was previously implemented with the following message:
    &gt; Bad line breaking before &#x27;{ token }&#x27;.
    This message does little to explain the rationale for the warning or the
    means to correct it. Re-phrase the message to better reflect the
    intention.
  * [[DOCS]] Replace Private Use Area character
    fixes [#3018](https://github.com/jshint/jshint/issues/3018)

2.9.3 / 2016-08-18
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * v2.9.3
  * [[CHORE]] Update dependency: cli ([#3010](https://github.com/jshint/jshint/issues/3010))
    The &#x60;cli&#x60; module at this version range was recently found to have a
    security vulnerability in a feature that is not used in JSHint. Update
    to the latest version which resolves the vulnerability by removing the
    affected functionality.
  * [[DOCS]] Fixed spelling of my name
  * [[FIX]] Support semicolons within arrow fn params ([#3003](https://github.com/jshint/jshint/issues/3003))
    When JSHint encounters an &quot;open parenthesis&quot; token, it must determine if
    the token marks the beginning of an arrow function or a grouping
    operator before parsing can proceed.
    To make this determination, it inspects the token stream to find the
    corresponding &quot;close parenthesis&quot; character.
    Previously, this lookahead behavior halted whenever a semicolon token
    was encountered. This was presumably an optimization to allow the
    algorithm to exit early in the event of an unmatched &quot;open parenthesis&quot;
    token.
    Because a semicolon token may appear in the parameter list of an arrow
    function (e.g. within a default parameter value that is a function
    expression), the presence of such a token does *not* necessarily
    indicate that the &quot;open parenthesis&quot; is unmatched.
    Remove the condition concerning the semicolon character from the
    lookahead algorithm.
  * [[FIX]] Allow Expression within for-in head
    As per the ES2015 language grammar:
    &gt; A.3 Statements
    &gt;
    &gt; [...]
    &gt;
    &gt; IterationStatement[Yield, Return] :
    &gt;
    &gt;   [...]
    &gt;
    &gt;   for ( [lookahead ∉ {let [}] LeftHandSideExpression[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
    &gt;   for ( var ForBinding[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
    &gt;   for ( ForDeclaration[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
    &gt;   for ( [lookahead ≠ let ] LeftHandSideExpression[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]
    &gt;   for ( var ForBinding[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]
    &gt;   for ( ForDeclaration[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]
    http://www.ecma-international.org/ecma-262/6.0/#sec-statements
  * [[FIX]] Support &#x60;y&#x60; RegExp flag in ES2015 code ([#2999](https://github.com/jshint/jshint/issues/2999))
  * Correct parsing of YieldExpression ([#2978](https://github.com/jshint/jshint/issues/2978))
    * [[CHORE]] Factor out Mozilla-specific parsing code
    Copy the &#x60;yield&#x60; parsing logic intended for Mozilla&#x27;s &quot;JavaScript 1.7&quot;
    to a dedicated function. This will reduce the risk of unintended
    breaking changes in forthcoming corrections to the parsing logic for the
    ECMAScript standard version of the language feature.
    * [[CHORE]] Streamline &#x60;yield&#x60; parsing logic
    The previous commit re-factored Mozilla-specific parsing logic for
    &#x60;yield&#x60; to a dedicated function, making it unnecessary to verify the
    &quot;inMoz()&quot; value within either version of the parsing function.
    * [[FIX]] Correct parsing of YieldExpression
    Correct errors in the parsing logic for the ES2015 YieldExpression.
    Update invalid unit tests and introduce additional tests.
    * fixup! [[CHORE]] Factor out Mozilla-specific parsing code
    * fixup! [[CHORE]] Streamline &#x60;yield&#x60; parsing logic
  * [[FIX]] Add TypedArray globals for ES2015
  * [[CHORE]] Refactor directive parsing logic ([#2992](https://github.com/jshint/jshint/issues/2992))
    Extend the recently-improved &#x60;isEndOfExpr&#x60; function so that it may be
    re-used during directive parsing, limiting duplication.
  * [[FIX]] Avoid crash when peeking past end of prog ([#2937](https://github.com/jshint/jshint/issues/2937))
    The lexer returns &#x60;null&#x60; values when tokens are requested after all
    input has been consumed. Previously, the &#x60;peek&#x60; function would correctly
    produce the special &quot;(end)&quot; token in situations where the parser
    attempted to look beyond the end of the program. In such cases, however,
    it would also pollute the lookahead buffer with an invalid entry--the
    &#x60;null&#x60; value returned by the lexer. Future calls to &#x60;peek&#x60; could receive
    this buffered value.
    Because JSHint&#x27;s internals are written with the assumption that &#x60;peek&#x60;
    always returns a token object, the &#x60;null&#x60; value would trigger a
    TypeError and subsequent program crash.
    Re-factor the &#x60;peek&#x60; function to only insert valid token objects into
    the lookahead buffer.
  * [[FIX]] Disallow Import declarations below top lvl
  * [[FIX]] Correctly recognize asi after directives
    Use the &#x60;parseFinalSemicolon&#x60; function instead of a custom
    implementation in the &#x60;directive&#x60; function.
    Fixes gh-2714
  * Run CI in &quot;latest&quot; and &quot;LTS&quot; releases of Node.js ([#2945](https://github.com/jshint/jshint/issues/2945))
    * [[TEST]] Remove brittle assertion
    One test for the Node.js command-line interface contains an assertion
    for the &#x60;message&#x60; property of an error object created by Node.js. These
    strings are not &quot;frozen,&quot; and are therefore subject to change between
    released of Node.js. Node.js version 6.0 makes such a change, which
    causes the aforementioned CLI test to fail.
    The surrounding assertions sufficiently verify the behavior under test,
    so the brittle assertion may be removed without affecting coverage.
    * [[TEST]] Run CI for Node.js &quot;current&quot; and &quot;LTS&quot;
  * [[FIX]] Correct interpretation of ASI ([#2977](https://github.com/jshint/jshint/issues/2977))
    Ensure JSHint observes correct automatic semicolon insertion semantics.
    This change also modifies parsing logic for the Mozilla &quot;JavaScript 1.7&quot;
    implementation of YieldExpression. There is no formal specificaion for
    that version of the language feature, so the validity of this change was
    experimentally confirmed.
  * [[FIX]] Correct behavior of singleGroups ([#2951](https://github.com/jshint/jshint/issues/2951))
    * [[FIX]] Correct behavior of singleGroups
    The grouping operator may be necessary if the right-binding power of the
    operator preceeding the &quot;(&quot; token is greater than the left-binding power
    of the operator immediately following it.
    The initial implementation approximated this behavior by using the
    readily-accessible left-binding power of both operators. This heuristic
    is not always accurate, however as in the following case:
    typeof (a + b);
    Here, the necessity of the grouping operator is determined by the
    right-binding power of the &#x60;typeof&#x60; operator.
    Extend the Pratt parser to make the right-binding power available to all
    null denotation (&quot;nud&quot;) functions. Remove an invalid unit test exposed
    by this improvement.
    * fixup! [[FIX]] Correct behavior of singleGroups
  * [[CHORE]] Update minimatch
    Version 3.0.2 of the &quot;minimatch&quot; module introduces a security fix
    related to regular expression parsing.
  * [[FEAT]] Error for literals on rhs of &#x60;instanceof&#x60;
    This patch adds a new error that is used when a literal is found on the
    right-hand side of the &#x60;instanceof&#x60; infix operator. A warning is used when a
    function declaration is found.
    Literals generate errors:
    x instanceof 0;
    x instanceof &#x27;&#x27;;
    x instanceof null;
    x instanceof undefined;
    x instanceof {};
    x instanceof [];
    x instanceof /./;
    x instanceof &#x60;&#x60;;
    Function declarations generate warnings:
    x instanceof function() {};
    x instanceof function MyUnusableFunction() {};
    But this is okay:
    x instanceof /x/.constructor;
    x instanceof &quot;&quot;.constructor;
    as per GH-2773
    References:
    Closes GH-2777
  * [[DOCS]] Add thanks for former maintainers

2.9.2 / 2016-04-19
&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;

  * v2.9.2
  * [[FIX]] Correct CLI&#x27;s indentation offset logic
    Don&#x27;t attempt to indent errors using data from other files, during
    extract with multiple files
    This change will fix the report of &#x60;col NaN&#x60; and the problem of &#x60;NaN&#x60; in
    &#x60;error.character&#x60; while checking JS code extracted from non-JS files,
    when more than one file has been passed in and their lengths don&#x27;t
    match.
    The function &#x60;extractOffsets&#x60; finds the number of characters a JS block
    must be shifted to show the correct character column for an error. The
    result is an array consisting of numbers, for the block it checked and,
    &#x60;undefined&#x60; for the lines it didn&#x27;t have to look at.  &#x60;cli.run&#x60; executes
    &#x60;extractOffsets&#x60; on each input file but wrongly tries to indent all the
    errors found so far, across files, using the current file&#x27;s offsets.
    This commit makes sure &#x60;cli.run&#x60; only indents errors of a file against
    the offsets fetched for the same file.
    This commit also makes sure that we don&#x27;t change or ruin the value of
    &#x60;error.character&#x60; unnecessarily.
    I have chosen to trust that &#x60;extractOffsets&#x60; will return an array with
    only numbers (as a result of Array.length) and falsy values, to avoid
    the unnecessary type conversion.
    A test named &#x60;usingMultipleFiles&#x60; has been introduced to cli.
    Fixes [#2778](https://github.com/jshint/jshint/issues/2778)
  * [[TEST]] Update expected warning message
  * [[DOCS]] Correct URL
  * [[FIX]] Reserve &#x60;await&#x60; keyword in ES6 module code
    From the ECMAScript 2015 specification:
    &gt; The following tokens are reserved for used as keywords in future
    &gt; language extensions.
    &gt;
    &gt;     Syntax
    &gt;         FutureReservedWord::
    &gt;             enum
    &gt;             await
    &gt;
    &gt; await is only treated as a FutureReservedWord when Module is the goal
    &gt; symbol of the syntactic grammar.
    http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
  * [[FIX]] Emit correct token value from &quot;module&quot; API
    * [[TEST]] Re-factor tests for &quot;module&quot; API
    Separate the project&#x27;s single unit test for the module API into a
    standalone file. Beyond improving test discoverability, this
    organization encapsulates new logic necessary for test hygiene (as
    described in the in-line documentation).
    * [[FIX]] Emit correct token value
    Correct a typo in the source which caused the value &#x60;undefined&#x60; to be
    emitted as the &#x60;from&#x60; property for all Identifier tokens, regardless of
    the actual character position.
  * [[FIX]] Account for implied closures
    Some environments wrap code in an immediately-invoked function
    expression prior to evaluation. This behavior has an effect on global
    &#x60;var&#x60; declarations. Unlike in typical JavaScript source code, such
    statements in these contexts do *not* create new entries in the
    environment record, nor do they resolve to references to the global
    binding (where defined).
    Update the logic that tracks global definitions to account for such
    environments, avoiding issuing warning W079 (&quot;Redefinition of &#x27;{a}&#x27;.&quot;)
    which is otherwise appropriate.
    Note: a far preferable solution would involve updating JSHint&#x27;s scope
    tracking mechanism to create a new entry for this implicit function
    scope. Unfortunately the legacy implementation of the environmental
    options allowed for usage scenarios that are incompatible with that
    approach (specifically: enabling the environment options after the
    source text has been partially parsed).
  * [[CHORE]] Remove I003
    This warning is inappropriate in cases where &#x60;esversion&#x60; has been
    globally set to a value other than &#x60;5&#x60; (e.g. in a project&#x27;s &#x60;.jshintrc&#x60;
    file) and a specific file overrides this value with an in-line
    directive.
    Although it is possible to detect this case while interpreting option
    values, the warning itself has minimal utility. Some users may set
    options to their default values in the interest of explicitness.
    Preventing this practice (and doing so inconsistently--only for the
    &#x60;esversion&#x60; option) adds little value.
    Remove I003 completely.
  * Improve contribution guidelines
    * [[DOCS]] Describe expectations for bug reports
    * [[DOCS]] Re-structure contribution guideliness
    Formalize the distinction between types of contributions to help
    contributors find the information that is relevant to their task.
    * [[DOCS]] Include guidance on feature requests
    * [[DOCS]] Remove outdate reference
  * [[FIX]] (cli - extract) lines can end with &quot;\\r\\n&quot;, not &quot;\\n\\r&quot;
    Fixes gh-2825
  * [[DOCS]] Describe location of release notes
    In an attempt to avoid confusion for those reading the release notes
    from varied locations (e.g. GitHub&#x27;s &quot;release&quot; pages), explicitly define
    where the release notes can be found.
  * [[FIX]] Add CompositionEvent to browser globals
    https://www.w3.org/TR/uievents/#events-compositionevents
  * [[FIX]] Allow parentheses around object destructuring assignment.
    Fixes gh-2775
  * [[FIX]] Allow destructuring in setter parameter
  * Merge pull request [#2831](https://github.com/jshint/jshint/issues/2831) from jugglinmike/improve-bad-assign
    Improve E031, &quot;Bad assignment.&quot;
  * [[FIX]] Expand forms accepted in dstr. assignment
    Align the parser&#x27;s expectations for assignment targets in destructuring
    patterns with its expectations in other assignment expressions.
  * [[FIX]] Report &quot;Bad assignment.&quot; in destructuring
    During destructuring, the return value of the internal
    &#x60;checkLeftSideAssign&#x60; function was discarded, so JSHint would fail to
    report invalid assignment targets in that context.
    Move the reporting of Error 031 (&quot;Bad assignment.&quot;) into the
    &#x60;checkLeftSideAssign&#x60; to enhance consistency. Improve the
    implementation of that internal function by making it aware of the rest
    operator (the previous implementation considered this form &quot;invalid&quot; but
    failed to report that).
  * [[FIX]] Improve binding power for tagged templates
    Use a more accurate value for tagged templates&#x27; binding power in order
    to ensure that the &#x60;singleGroups&#x60; option correctly permits use of the
    grouping operator where it is truly necessary.
  * [[CHORE]] Use pratt mechanics to parse tagged templates
  * [[FIX]] Make the &#x27;freeze&#x27; option less strict
    Don&#x27;t warn when the prototype of a local variable
    named as a native object is modified.
    Fixes gh-1600
  * [[FIX]] Report character position for camelcase errors
    Character positions were not being reported when camelcase errors were detected.
    This fix will now report the character position correctly.
    Fixes [#2845](https://github.com/jshint/jshint/issues/2845)
  * [[DOCS]] Remove deprecated es5 and esnext options
    This removes the deprecated &#x60;es5&#x60; and &#x60;esnext&#x60; options from the example
    file.
  * Merge pull request [#2843](https://github.com/jshint/jshint/issues/2843) from jugglinmike/2836-bad-options-4
    [[FIX]] Do not fail on valid configurations
  * Merge branch &#x27;let-used-before-in-two-functions&#x27;
  * [[CHORE]] Complete test coverage for recent fix
    In resolving a regression, the previous commit modified the way JSHint
    interprets references to variable bindings, but it did not fully test
    the new implementation. Extend the tests for the bug fix to fully assert
    its effects.
  * [[FIX]] Do not fail on valid configurations
    When interpreting configuration values for strict-mode-related options,
    do not modify user-specified values. Instead, preserve the values as
    specified and encapsulate interpretation logic into stateless helper
    methods on the &#x60;state&#x60; object.
    This pattern allows JSHint to consistently issue warnings about invalid
    configurations by ensuring that at any given time, all option values in
    the &#x60;state&#x60; object reflect values explicitly specified by the user.
    As noted in the in-line documentation, this approach required making
    explicit certain sub-optimal behaviors which were previously implicit.
    These concerns would best be addressed in a later patch, distinct from
    the regression that prompted this changeset.
  * [[CHORE]] Add test for legacy behavior
  * [[FIX]] Don&#x27;t throw E056 for vars used in two functions
    Fixes gh-2838
  * [[FIX]] Do not crash on invalid input
    fip renaming of comma var
    - function is now called parseComma
    - local var has be switched back to just comma
    Fixes the bug where we would overwrite the parseComma function (when
    they were both named comma)
  * [[FIX]] Allow regex inside template literal
    Fixes gh-2791
  * [[FIX]] Allow regexp literal after &#x27;instanceof&#x27;
    Fixes gh-2773
  * [[CHORE]] Pass correct parameter to state.inES6
  * [[FIX]] Improve reporting of &quot;Bad assignment.&quot;
    When an assignment expression has an invalid left-hand side, JSHint
    previously issued error E013 (&quot;Bad assignment.&quot;), bailed out of
    assignment interpretation and instead interpreted the left-hand side as
    an ExpressionStatement.
    In issuing E013, JSHint interprets the invalid JavaScript as an
    assignment expression. Failing to parse the invalid target as the
    left-hand side of the expression is inconsistent with this
    interpretation. The inconsistency commonly triggers inappropriate (and
    potentially confusing) errors such as &quot;Missing semicolon,&quot; and &quot;Expected
    an assignment or function call and instead saw an expression.&quot;
    Instead, JSHint should warn about the faulty assignment but continue
    parsing as though the expression were a valid assignment target. Doing
    so avoids emitting those errors that suggest that the left-hand side
    were written as an ExpressionStatement.
    1. Interpret faulty assignment targets as the left-hand side of
    assignment expressions in all cases, issuing error E013 and moving on
    2. Remove inappropriate errors from affected unit tests (noting that the
    underlying &quot;Bad assignment.&quot; error remains unchanged)