### PR TITLE
Add node-cache-manager-memory-store link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ See the [Express.js cache-manager example app](https://github.com/BryanDonovan/n
 
 * [node-cache-manager-memcached-store](https://github.com/theogravity/node-cache-manager-memcached-store)
 
+* [node-cache-manager-memory-store](https://github.com/theogravity/node-cache-manager-memory-store)
+
 ## Overview
 
 First, it includes a `wrap` function that lets you wrap any function in cache.


### PR DESCRIPTION
I note that `node-cache-manager` already has a memory store by default in my repo.