### PR TITLE
Add human readable ttl support

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -1,6 +1,7 @@
 /** @module cacheManager/caching */
 /*jshint maxcomplexity:15*/
 var CallbackFiller = require('./callback_filler');
+var ms = require('ms');
 
 /**
  * Generic caching interface that wraps any caching library with a compatible interface.
@@ -117,6 +118,9 @@ var caching = function(args) {
                     if (options && typeof options.ttl === 'function') {
                         options.ttl = options.ttl(data);
                     }
+                    if (options && typeof options.ttl === 'string') {
+                        options.ttl = parseInt(ms(options.ttl) / 1000, 10);
+                    }
 
                     self.store.set(key, data, options, function(err) {
                         if (err && (!self.ignoreCacheErrors)) {
@@ -187,6 +191,9 @@ var caching = function(args) {
      */
     if (typeof self.store.ttl === 'function') {
         self.ttl = self.store.ttl.bind(self.store);
+    }
+    if (typeof self.store.ttl === 'string') {
+        self.ttl = parseInt(ms(self.store.ttl) / 1000, 10);
     }
 
     return self;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.2",
-    "lru-cache": "4.0.0"
+    "lru-cache": "4.0.0",
+    "ms": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.3.0",


### PR DESCRIPTION
Using [ms](https://github.com/zeit/ms) to parse ttl if ttl is a string.

Examples: `ttl: '1 day'`, `ttl: '3.2 hours'`.