### PR TITLE
feature: allow setting, getting and deleting  multiple keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .idea
 *.iml
 out
+.vscode

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [Express.js cache-manager example app](https://github.com/BryanDonovan/n
 
 ## Overview
 
-First, it includes a `wrap` function that lets you wrap any function in cache.
+**First**, it includes a `wrap` function that lets you wrap any function in cache.
 (Note, this was inspired by [node-caching](https://github.com/mape/node-caching).)
 This is probably the feature you're looking for.  As an example, where you might have to do this:
 
@@ -82,12 +82,14 @@ function getCachedUser(id, cb) {
 }
 ```
 
-Second, node-cache-manager features a built-in memory cache (using [node-lru-cache](https://github.com/isaacs/node-lru-cache)),
+**Second**, node-cache-manager features a built-in memory cache (using [node-lru-cache](https://github.com/isaacs/node-lru-cache)),
 with the standard functions you'd expect in most caches:
 
     set(key, val, {ttl: ttl}, cb) // * see note below
     get(key, cb)
     del(key, cb)
+    mset(key1, val1, key2, val2, {ttl: ttl}, cb) // set several keys at once
+    mget(key1, key2, key3, cb) // get several keys at once
 
     // * Note that depending on the underlying store, you may be able to pass the
     // ttl as the third param, like this:
@@ -95,7 +97,7 @@ with the standard functions you'd expect in most caches:
     // ... or pass no ttl at all:
     set(key, val, cb)
 
-Third, node-cache-manager lets you set up a tiered cache strategy.  This may be of
+**Third**, node-cache-manager lets you set up a tiered cache strategy.  This may be of
 limited use in most cases, but imagine a scenario where you expect tons of
 traffic, and don't want to hit your primary cache (like Redis) for every request.
 You decide to store the most commonly-requested data in an in-memory cache,
@@ -104,6 +106,8 @@ still want to store the data in Redis for backup, and for the requests that
 aren't as common as the ones you want to store in memory. This is something
 node-cache-manager handles easily and transparently.
 
+
+**Fourth**, it allows you to get and set multiple keys at once for caching store that support it. This means that when getting muliple keys it will go through the different caches starting from the highest priority one (see multi store below) and merge the values it finds at each level.
 
 ## Usage Examples
 
@@ -176,6 +180,41 @@ memoryCache.wrap(key, function(cb) {
 }, opts, function(err, user) {
     console.log(user);
 }
+```
+
+You can get several keys at once. E.g.
+
+```js
+
+var key1 = 'user_1';
+var key2 = 'user_1';
+
+memoryCache.wrap(key1, key2, function (cb) {
+    getManyUser([key1, key2], cb);
+}, function (err, users) {
+    console.log(users[0]);
+    console.log(users[1]);
+});
+```
+
+#### Example setting/getting several keys with mset() and mget()
+
+```js
+memoryCache.mset('foo', 'bar', 'foo2', 'bar2' {ttl: ttl}, function(err) {
+    if (err) { throw err; }
+
+    memoryCache.mget('foo', 'foo2', function(err, result) {
+        console.log(result);
+        // >> ['bar', 'bar2']
+
+        // Delete keys with del() passing arguments...
+        memoryCache.del('foo', 'foo2', function(err) {});
+
+        // ...passing an Array of keys
+        memoryCache.del(['foo', 'foo2'], function(err) {});
+    });
+});
+
 ```
 
 #### Example Using Promises
@@ -275,6 +314,30 @@ multiCache.set('foo2', 'bar2', {ttl: ttl}, function(err) {
     });
 });
 
+// Sets multiple keys in all caches.
+// You can pass as many key,value pair as you want
+multiCache.mset('key', 'value', 'key2', 'value2', {ttl: ttl}, function(err) {
+    if (err) { throw err; }
+
+    // mget() fetches from highest priority cache.
+    // If the first cache does not return all the keys,
+    // the next cache is fetched with the keys that were not found.
+    // This is done recursively until either:
+    // - all have been found
+    // - all caches has been fetched
+    multiCache.mget('key', 'key2', function(err, result) {
+        console.log(result[0]);
+        console.log(result[1]);
+        // >> 'bar2'
+        // >> 'bar3'
+
+        // Delete from all caches
+        multiCache.del('key', 'key2');
+        // ...or with an Array
+        multiCache.del(['key', 'key2']);
+    });
+});
+
 // Note: options with ttl are optional in wrap()
 multiCache.wrap(key2, function (cb) {
     getUser(userId2, cb);
@@ -289,6 +352,14 @@ multiCache.wrap(key2, function (cb) {
     }, function (err, user) {
         console.log(user);
     });
+});
+
+// Multiple keys
+multiCache.wrap('key1', 'key2', function (cb) {
+    getManyUser(['key1', 'key2'], cb);
+}, {ttl: ttl}, function (err, users) {
+    console.log(users[0]);
+    console.log(users[1]);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ key2 = 'user_' + userId;
 ttl = 5;
 
 // Sets in all caches.
+// The "ttl" option can also be a function (see example below)
 multiCache.set('foo2', 'bar2', {ttl: ttl}, function(err) {
     if (err) { throw err; }
 
@@ -314,9 +315,17 @@ multiCache.set('foo2', 'bar2', {ttl: ttl}, function(err) {
     });
 });
 
+// Set the ttl value by context depending on the store.
+function getTTL(data, store) {
+    if (store === 'redis') {
+        return 6000;
+    }
+    return 3000;
+}
+
 // Sets multiple keys in all caches.
 // You can pass as many key,value pair as you want
-multiCache.mset('key', 'value', 'key2', 'value2', {ttl: ttl}, function(err) {
+multiCache.mset('key', 'value', 'key2', 'value2', {ttl: getTTL}, function(err) {
     if (err) { throw err; }
 
     // mget() fetches from highest priority cache.

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -1,6 +1,8 @@
 /** @module cacheManager/caching */
-/*jshint maxcomplexity:15*/
+/*jshint maxcomplexity:16*/
 var CallbackFiller = require('./callback_filler');
+var utils = require('./utils');
+var parseWrapArguments = utils.parseWrapArguments;
 
 /**
  * Generic caching interface that wraps any caching library with a compatible interface.
@@ -47,12 +49,12 @@ var caching = function(args) {
         return new Promise(function(resolve, reject) {
             self.wrap(key, function(cb) {
                 Promise.resolve()
-                .then(promise)
-                .then(function(result) {
-                    cb(null, result);
-                    return null;
-                })
-                .catch(cb);
+                    .then(promise)
+                    .then(function(result) {
+                        cb(null, result);
+                        return null;
+                    })
+                    .catch(cb);
             }, options, function(err, result) {
                 if (err) {
                     return reject(err);
@@ -66,32 +68,56 @@ var caching = function(args) {
      * Wraps a function in cache. I.e., the first time the function is run,
      * its results are stored in cache so subsequent calls retrieve from cache
      * instead of calling the function.
+     * You can pass any number of keys as long as the wrapped function returns
+     * an array with the same number of values and in the same order.
      *
      * @function
      * @name wrap
      *
-     * @param {string} key - The cache key to use in cache operations
+     * @param {string} key - The cache key to use in cache operations. Can be one or many.
      * @param {function} work - The function to wrap
      * @param {object} [options] - options passed to `set` function
      * @param {function} cb
      *
      * @example
-     *   var key = 'user_' + userId;
-     *   cache.wrap(key, function(cb) {
-     *       User.get(userId, cb);
-     *   }, function(err, user) {
-     *       console.log(user);
-     *   });
+     * var key = 'user_' + userId;
+     * cache.wrap(key, function(cb) {
+     *     User.get(userId, cb);
+     * }, function(err, user) {
+     *     console.log(user);
+     * });
+     *
+     * // Multiple keys
+     * var key = 'user_' + userId;
+     * var key2 = 'user_' + userId2;
+     * cache.wrap(key, key2, function(cb) {
+     *     User.getMany([userId, userId2], cb);
+     * }, function(err, users) {
+     *     console.log(users[0]);
+     *     console.log(users[1]);
+     * });
      */
-    self.wrap = function(key, work, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
-        }
+    self.wrap = function() {
+        var parsedArgs = parseWrapArguments(Array.prototype.slice.apply(arguments));
+        var keys = parsedArgs.keys;
+        var work = parsedArgs.work;
+        var options = parsedArgs.options;
+        var cb = parsedArgs.cb;
 
         if (!cb) {
-            return wrapPromise(key, work, options);
+            keys.push(work);
+            keys.push(options);
+            return wrapPromise.apply(this, keys);
         }
+
+        if (keys.length > 1) {
+            /**
+             * Handle more than 1 key
+             */
+            return wrapMultiple(keys, work, options, cb);
+        }
+
+        var key = keys[0];
 
         var hasKey = callbackFiller.has(key);
         callbackFiller.add(key, {cb: cb});
@@ -130,6 +156,85 @@ var caching = function(args) {
         });
     };
 
+    function wrapMultiple(keys, work, options, cb) {
+        /**
+         * We create a unique key for the multiple keys
+         * by concatenating them
+         */
+        var combinedKey = keys.reduce(function(acc, k) {
+            return acc + k;
+        }, '');
+
+        var hasKey = callbackFiller.has(combinedKey);
+        callbackFiller.add(combinedKey, {cb: cb});
+        if (hasKey) { return; }
+
+        keys.push(options);
+        keys.push(onResult);
+
+        self.store.mget.apply(self.store, keys);
+
+        function onResult(err, result) {
+            if (err && (!self.ignoreCacheErrors)) {
+                return callbackFiller.fill(combinedKey, err);
+            }
+
+            /**
+            * If all the values returned are cacheable we don't need
+            * to call our "work" method and the values returned by the cache
+            * are valid. If one or more of the values is not cacheable
+            * the cache result is not valid.
+            */
+            var cacheOK = Array.isArray(result) && result.filter(function(_result) {
+                return self._isCacheableValue(_result);
+            }).length === result.length;
+
+            if (cacheOK) {
+                return callbackFiller.fill(combinedKey, null, result);
+            }
+
+            return work(function(err, data) {
+                if (err) {
+                    return done(err);
+                }
+
+                var _args = [];
+                data.forEach(function(value, i) {
+                    /**
+                     * Add the {key, value} pair to the args
+                     * array that we will send to mset()
+                     */
+                    if (self._isCacheableValue(value)) {
+                        _args.push(keys[i]);
+                        _args.push(value);
+                    }
+                });
+
+                // If no key|value, exit
+                if (_args.length === 0) {
+                    return done(null);
+                }
+
+                if (options && typeof options.ttl === 'function') {
+                    options.ttl = options.ttl(data);
+                }
+
+                _args.push(options);
+                _args.push(done);
+
+                self.store.mset.apply(self.store, _args);
+
+                function done(err) {
+                    if (err && (!self.ignoreCacheErrors)) {
+                        callbackFiller.fill(combinedKey, err);
+                    } else {
+                        callbackFiller.fill(combinedKey, null, data);
+                    }
+                }
+            });
+        }
+    }
+
     /**
      * Binds to the underlying store's `get` function.
      * @function
@@ -138,11 +243,32 @@ var caching = function(args) {
     self.get = self.store.get.bind(self.store);
 
     /**
+     * Get multiple keys at once.
+     * Binds to the underlying store's `mget` function.
+     * @function
+     * @name mget
+     */
+    if (typeof self.store.mget === 'function') {
+        self.mget = self.store.mget.bind(self.store);
+    }
+
+    /**
      * Binds to the underlying store's `set` function.
      * @function
      * @name set
      */
     self.set = self.store.set.bind(self.store);
+
+    /**
+     * Set multiple keys at once.
+     * It accepts any number of {key, value} pair
+     * Binds to the underlying store's `mset` function.
+     * @function
+     * @name mset
+     */
+    if (typeof self.store.mset === 'function') {
+        self.mset = self.store.mset.bind(self.store);
+    }
 
     /**
      * Binds to the underlying store's `del` function if it exists.

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -234,6 +234,15 @@ var multiCaching = function(caches, options) {
                 return next();
             }
 
+            var cacheOptions = options;
+            if (typeof options.ttl === 'function') {
+                /**
+                 * Dynamically set the ttl by context depending of the store
+                 */
+                cacheOptions = {};
+                cacheOptions.ttl = options.ttl(keysValues, cache.store.name);
+            }
+
             if (multi) {
                 if (typeof cache.store.mset !== 'function') {
                     /**
@@ -241,12 +250,12 @@ var multiCaching = function(caches, options) {
                      */
                     return next();
                 }
-                keysValues.push(options);
+                keysValues.push(cacheOptions);
                 keysValues.push(next);
 
                 cache.store.mset.apply(cache.store, keysValues);
             } else {
-                cache.store.set(keysValues[0], keysValues[1], options, next);
+                cache.store.set(keysValues[0], keysValues[1], cacheOptions, next);
             }
         }, function(err, result) {
             cb(err, result);

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -1,6 +1,9 @@
 /** @module cacheManager/multiCaching */
 var async = require('async');
 var CallbackFiller = require('./callback_filler');
+var utils = require('./utils');
+var isObject = utils.isObject;
+var parseWrapArguments = utils.parseWrapArguments;
 
 /**
  * Module that lets you specify a hierarchy of caches.
@@ -48,25 +51,63 @@ var multiCaching = function(caches, options) {
         }
     }
 
-    function getFromHighestPriorityCachePromise(key, options) {
+    function getFromHighestPriorityCachePromise() {
+        var args = Array.prototype.slice.apply(arguments).filter(function(v) {
+            return typeof v !== 'undefined';
+        });
+
         return new Promise(function(resolve, reject) {
-            getFromHighestPriorityCache(key, options, function(err, result) {
+            var cb = function(err, result) {
                 if (err) {
                     return reject(err);
                 }
                 resolve(result);
-            });
+            };
+            args.push(cb);
+            getFromHighestPriorityCache.apply(null, args);
         });
     }
 
-    function getFromHighestPriorityCache(key, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
+    function getFromHighestPriorityCache() {
+        var args = Array.prototype.slice.apply(arguments).filter(function(v) {
+            return typeof v !== 'undefined';
+        });
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
         }
 
         if (!cb) {
-            return getFromHighestPriorityCachePromise(key, options);
+            return getFromHighestPriorityCachePromise.apply(this, args);
+        }
+
+        if (isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        /**
+         * Keep a copy of the keys to retrieve
+         */
+        var keys = Array.prototype.slice.apply(args);
+        var multi = keys.length > 1;
+
+        /**
+         * Then put back the options in the args Array
+         */
+        args.push(options);
+
+        if (multi) {
+            /**
+             * Keep track of the keys left to fetch accross the caches
+             */
+            var keysToFetch = Array.prototype.slice.apply(keys);
+
+            /**
+             * Hash to save our multi keys result
+             */
+            var mapResult = {};
         }
 
         var i = 0;
@@ -78,7 +119,16 @@ var multiCaching = function(caches, options) {
 
                 var _isCacheableValue = getIsCacheableValueFunction(cache);
 
-                if (_isCacheableValue(result)) {
+                if (multi) {
+                    addResultToMap(result, _isCacheableValue);
+
+                    if (keysToFetch.length === 0 || i === caches.length - 1) {
+                        // Return an Array with the values merged from all the caches
+                        return cb(null, keys.map(function(k) {
+                            return mapResult[k] || undefined;
+                        }), i);
+                    }
+                } else if (_isCacheableValue(result)) {
                     // break out of async loop.
                     return cb(err, result, i);
                 }
@@ -87,37 +137,116 @@ var multiCaching = function(caches, options) {
                 next();
             };
 
-            cache.store.get(key, options, callback);
+            if (multi) {
+                if (typeof cache.store.mget !== 'function') {
+                    /**
+                     * Silently fail for store that don't support mget()
+                     */
+                    return callback(null, []);
+                }
+                var _args = Array.prototype.slice.apply(keysToFetch);
+                _args.push(options);
+                _args.push(callback);
+                cache.store.mget.apply(cache.store, _args);
+            } else {
+                cache.store.get(args[0], options, callback);
+            }
         }, function(err, result) {
             return cb(err, result);
         });
+
+        function addResultToMap(result, isCacheable) {
+            var key;
+            var diff = 0;
+
+            /**
+             * We loop through the result and if the value
+             * is cacheable we add it to the mapResult hash
+             * and remove the key to fetch from the "keysToFetch" array
+             */
+            result.forEach(function(res, i) {
+                if (isCacheable(res)) {
+                    key = keysToFetch[i - diff];
+
+                    // Add the result to our map
+                    mapResult[key] = res;
+
+                    // delete key from our keysToFetch array
+                    keysToFetch.splice(i, 1);
+                    diff += 1;
+                }
+            });
+        }
     }
 
-    function setInMultipleCachesPromise(caches, opts) {
+    function setInMultipleCachesPromise() {
+        var args = Array.prototype.slice.apply(arguments);
+
         return new Promise(function(resolve, reject) {
-            setInMultipleCaches(caches, opts, function(err, result) {
+            var cb = function(err, result) {
                 if (err) {
                     return reject(err);
                 }
                 resolve(result);
-            });
+            };
+            args.push(cb);
+            setInMultipleCaches.apply(null, args);
         });
     }
 
-    function setInMultipleCaches(caches, opts, cb) {
-        opts.options = opts.options || {};
+    function setInMultipleCaches() {
+        var args = Array.prototype.slice.apply(arguments);
+        var _caches = Array.isArray(args[0]) ? args.shift() : caches;
 
-        if (!cb) {
-            return setInMultipleCachesPromise(caches, opts);
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
         }
 
-        async.each(caches, function(cache, next) {
-            var _isCacheableValue = getIsCacheableValueFunction(cache);
+        if (!cb) {
+            return setInMultipleCachesPromise.apply(this, args);
+        }
 
-            if (_isCacheableValue(opts.value)) {
-                cache.store.set(opts.key, opts.value, opts.options, next);
+        if (isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        var length = args.length;
+        var multi = length > 2;
+        var i;
+
+        async.each(_caches, function(cache, next) {
+            var _isCacheableValue = getIsCacheableValueFunction(cache);
+            var keysValues = Array.prototype.slice.apply(args);
+
+            /**
+             * We filter out the keys *not* cacheable
+             */
+            for (i = 0; i < length; i += 2) {
+                if (!_isCacheableValue(keysValues[i + 1])) {
+                    keysValues.splice(i, 2);
+                }
+            }
+
+            if (keysValues.length === 0) {
+                return next();
+            }
+
+            if (multi) {
+                if (typeof cache.store.mset !== 'function') {
+                    /**
+                     * Silently fail for store that don't support mset()
+                     */
+                    return next();
+                }
+                keysValues.push(options);
+                keysValues.push(next);
+
+                cache.store.mset.apply(cache.store, keysValues);
             } else {
-                next();
+                cache.store.set(keysValues[0], keysValues[1], options, next);
             }
         }, function(err, result) {
             cb(err, result);
@@ -194,29 +323,38 @@ var multiCaching = function(caches, options) {
      * without getting set in other lower-priority caches.
      * If a key doesn't exist in a higher-priority cache but exists in a lower-priority
      * cache, it gets set in all higher-priority caches.
+     * You can pass any number of keys as long as the wrapped function returns
+     * an array with the same number of values and in the same order.
      *
-     * @param {string} key - The cache key to use in cache operations
+     * @function
+     * @name wrap
+     *
+     * @param {string} key - The cache key to use in cache operations. Can be one or many.
      * @param {function} work - The function to wrap
      * @param {object} [options] - options passed to `set` function
      * @param {function} cb
      */
-    self.wrap = function(key, work, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
-        }
-
-        function getOptsForSet(value) {
-            return {
-                key: key,
-                value: value,
-                options: options
-            };
-        }
+    self.wrap = function() {
+        var parsedArgs = parseWrapArguments(Array.prototype.slice.apply(arguments));
+        var keys = parsedArgs.keys;
+        var work = parsedArgs.work;
+        var options = parsedArgs.options;
+        var cb = parsedArgs.cb;
 
         if (!cb) {
-            return wrapPromise(key, work, options);
+            keys.push(work);
+            keys.push(options);
+            return wrapPromise.apply(this, keys);
         }
+
+        if (keys.length > 1) {
+            /**
+             * Handle more than 1 key
+             */
+            return wrapMultiple(keys, work, options, cb);
+        }
+
+        var key = keys[0];
 
         var hasKey = callbackFiller.has(key);
         callbackFiller.add(key, {cb: cb});
@@ -227,11 +365,11 @@ var multiCaching = function(caches, options) {
                 return callbackFiller.fill(key, err);
             } else if (self._isCacheableValue(result)) {
                 var cachesToUpdate = caches.slice(0, index);
-                var opts = getOptsForSet(result);
-
-                setInMultipleCaches(cachesToUpdate, opts, function(err) {
+                var args = [cachesToUpdate, key, result, options, function(err) {
                     callbackFiller.fill(key, err, result);
-                });
+                }];
+
+                setInMultipleCaches.apply(null, args);
             } else {
                 work(function(err, data) {
                     if (err) {
@@ -242,15 +380,134 @@ var multiCaching = function(caches, options) {
                         return callbackFiller.fill(key, err, data);
                     }
 
-                    var opts = getOptsForSet(data);
-
-                    setInMultipleCaches(caches, opts, function(err) {
+                    var args = [caches, key, data, options, function(err) {
                         callbackFiller.fill(key, err, data);
-                    });
+                    }];
+
+                    setInMultipleCaches.apply(null, args);
                 });
             }
         });
     };
+
+    function wrapMultiple(keys, work, options, cb) {
+        /**
+         * We create a unique key for the multiple keys
+         * by concatenating them
+         */
+        var combinedKey = keys.reduce(function(acc, k) {
+            return acc + k;
+        }, '');
+
+        var hasKey = callbackFiller.has(combinedKey);
+        callbackFiller.add(combinedKey, {cb: cb});
+        if (hasKey) { return; }
+
+        keys.push(options);
+        keys.push(onResult);
+
+        /**
+         * Get from all the caches. If multiple keys have been passed,
+         * we'll go through all the caches and merge the result
+         */
+        getFromHighestPriorityCache.apply(this, keys);
+
+        function onResult(err, result, index) {
+            if (err) {
+                return done(err);
+            }
+
+            /**
+             * If all the values returned are cacheable we don't need
+             * to call our "work" method and the values returned by the cache
+             * are valid. If one or more of the values is not cacheable
+             * the cache result is not valid.
+             */
+            var cacheOK = result.filter(function(_result) {
+                return self._isCacheableValue(_result);
+            }).length === result.length;
+
+            if (!cacheOK) {
+                /**
+                 * We need to fetch the data first
+                 */
+                return work(workCallback);
+            }
+
+            var cachesToUpdate = caches.slice(0, index);
+
+            /**
+             * Prepare arguments to set the values in
+             * higher priority caches
+             */
+            var _args = [cachesToUpdate];
+
+            /**
+             * Add the {key, value} pair
+             */
+            result.forEach(function(value, i) {
+                _args.push(keys[i]);
+                _args.push(value);
+            });
+
+            /**
+             * Add options and final callback
+             */
+            _args.push(options);
+            _args.push(function(err) {
+                done(err, result);
+            });
+
+            return setInMultipleCaches.apply(null, _args);
+
+            /**
+             * Wrapped function callback
+             */
+            function workCallback(err, data) {
+                if (err) {
+                    return done(err);
+                }
+
+                /**
+                 * Prepare arguments for "setInMultipleCaches"
+                 */
+                var _args;
+
+                _args = [];
+                data.forEach(function(value, i) {
+                    /**
+                     * Add the {key, value} pair to the args
+                     * array that we will send to mset()
+                     */
+                    if (self._isCacheableValue(value)) {
+                        _args.push(keys[i]);
+                        _args.push(value);
+                    }
+                });
+                // If no key,value --> exit
+                if (_args.length === 0) {
+                    return done(null);
+                }
+
+                /**
+                 * Add options and final callback
+                 */
+                _args.push(options);
+                _args.push(function(err) {
+                    done(err, data);
+                });
+
+                setInMultipleCaches.apply(null, _args);
+            }
+
+            /**
+             * Final callback
+             */
+            function done(err, data) {
+                callbackFiller.fill(combinedKey, err, data);
+            }
+        }
+    }
 
     /**
      * Set value in all caches
@@ -263,20 +520,23 @@ var multiCaching = function(caches, options) {
      * @param {object} [options] to pass to underlying set function.
      * @param {function} [cb]
      */
-    self.set = function(key, value, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
-        }
+    self.set = setInMultipleCaches;
 
-        var opts = {
-            key: key,
-            value: value,
-            options: options
-        };
-
-        return setInMultipleCaches(caches, opts, cb);
-    };
+    /**
+     * Set multiple values in all caches
+     * Accepts an unlimited pair of {key, value}
+     *
+     * @function
+     * @name mset
+     *
+     * @param {string} key
+     * @param {*} value
+     * @param {string} [key2]
+     * @param {*} [value2]
+     * @param {object} [options] to pass to underlying set function.
+     * @param {function} [cb]
+     */
+    self.mset = setInMultipleCaches;
 
     /**
      * Get value from highest level cache that has stored it.
@@ -288,14 +548,22 @@ var multiCaching = function(caches, options) {
      * @param {object} [options] to pass to underlying get function.
      * @param {function} cb
      */
-    self.get = function(key, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
-        }
+    self.get = getFromHighestPriorityCache;
 
-        return getFromHighestPriorityCache(key, options, cb);
-    };
+    /**
+     * Get multiple value from highest level cache that has stored it.
+     * If some values are not found, the next highest cache is used
+     * until either all keys are found or all caches have been fetched.
+     * Accepts an unlimited number of keys.
+     *
+     * @function
+     * @name mget
+     *
+     * @param {string} key key to get (any number)
+     * @param {object} [options] to pass to underlying get function.
+     * @param {function} cb optional callback
+     */
+    self.mget = getFromHighestPriorityCache;
 
     /**
      * Delete value from all caches.
@@ -307,14 +575,24 @@ var multiCaching = function(caches, options) {
      * @param {object} [options] to pass to underlying del function.
      * @param {function} cb
      */
-    self.del = function(key, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
-            options = {};
+    self.del = function() {
+        var args = Array.prototype.slice.apply(arguments);
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
         }
 
+        if (isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        args.push(options);
         async.each(caches, function(cache, next) {
-            cache.store.del(key, options, next);
+            var _args = Array.prototype.slice.apply(args);
+            _args.push(next);
+            cache.store.del.apply(cache.store, _args);
         }, cb);
     };
 

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -1,4 +1,6 @@
 var Lru = require("lru-cache");
+var utils = require('../utils');
+var isObject = utils.isObject;
 
 var memoryStore = function(args) {
     args = args || {};
@@ -18,6 +20,16 @@ var memoryStore = function(args) {
 
     var lruCache = new Lru(lruOpts);
 
+    var setMultipleKeys = function setMultipleKeys(keysValues, maxAge) {
+        var length = keysValues.length;
+        var values = [];
+        for (var i = 0; i < length; i += 2) {
+            lruCache.set(keysValues[i], keysValues[i + 1], maxAge);
+            values.push(keysValues[i + 1]);
+        }
+        return values;
+    };
+
     self.set = function(key, value, options, cb) {
         if (typeof options === 'function') {
             cb = options;
@@ -32,6 +44,30 @@ var memoryStore = function(args) {
             process.nextTick(cb.bind(null, null));
         } else if (self.usePromises) {
             return Promise.resolve(value);
+        }
+    };
+
+    self.mset = function() {
+        var args = Array.prototype.slice.apply(arguments);
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
+        }
+
+        if (args.length % 2 > 0 && isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.maxAge;
+
+        var values = setMultipleKeys(args, maxAge);
+
+        if (cb) {
+            process.nextTick(cb.bind(null, null));
+        } else if (self.usePromises) {
+            return Promise.resolve(values);
         }
     };
 
@@ -50,12 +86,52 @@ var memoryStore = function(args) {
         }
     };
 
-    self.del = function(key, options, cb) {
-        if (typeof options === 'function') {
-            cb = options;
+    self.mget = function() {
+        var args = Array.prototype.slice.apply(arguments);
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
         }
 
-        lruCache.del(key);
+        if (isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        var values = args.map(function(key) {
+            return lruCache.get(key);
+        });
+
+        if (cb) {
+            process.nextTick(cb.bind(null, null, values));
+        } else if (self.usePromises) {
+            return Promise.resolve(values);
+        } else {
+            return values;
+        }
+    };
+
+    self.del = function() {
+        var args = Array.prototype.slice.apply(arguments);
+        var cb;
+        var options = {};
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
+        }
+
+        if (isObject(args[args.length - 1])) {
+            options = args.pop();
+        }
+
+        if (Array.isArray(args[0])) {
+            args = args[0];
+        }
+
+        args.forEach(function(key) {
+            lruCache.del(key);
+        });
 
         if (cb) {
             process.nextTick(cb.bind(null, null));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,43 @@
+
+var isObject = function isObject(value) {
+    return value instanceof Object && value.constructor === Object;
+};
+
+var parseWrapArguments = function parseWrapArguments(args) {
+    var length = args.length;
+    var work;
+    var options = {};
+    var cb;
+
+    /**
+     * As we can receive an unlimited number of keys
+     * we find the index of the first function which is
+     * the "work" handler to fetch the keys.
+     */
+    for (var i = 0; i < length; i += 1) {
+        if (typeof args[i] === 'function') {
+            if (typeof args[i + 2] === 'function') {
+                cb = args.pop();
+            } else if (typeof args[i + 1] === 'function') {
+                cb = args.pop();
+            }
+            if (isObject(args[i + 1])) {
+                options = args.pop();
+            }
+            work = args.pop();
+            break;
+        }
+    }
+
+    return {
+        keys: args,
+        work: work,
+        options: options,
+        cb: cb
+    };
+};
+
+module.exports = {
+    isObject: isObject,
+    parseWrapArguments: parseWrapArguments,
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "es6-promise": "^3.0.2",
     "istanbul": "0.4.2",
     "jscs": "2.11.0",
-    "jsdoc": "3.3.0",
+    "jsdoc": "3.5.5",
     "jshint": "2.9.1",
     "mocha": "2.4.5",
     "optimist": "0.6.1",

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -14,7 +14,12 @@ var methods = {
         process.nextTick(function() {
             cb(null, {name: name});
         });
-    }
+    },
+    getMultiWidget: function(names, cb) {
+        process.nextTick(function() {
+            cb(null, names.map(function(name) { return {name: name}; }));
+        });
+    },
 };
 
 describe("multiCaching", function() {
@@ -23,8 +28,10 @@ describe("multiCaching", function() {
     var memoryCache3;
     var multiCache;
     var key;
+    var key2;
     var memoryTtl;
     var name;
+    var name2;
     var defaultTtl;
 
     beforeEach(function() {
@@ -36,16 +43,21 @@ describe("multiCaching", function() {
         memoryCache3 = caching({store: 'memory', ttl: memoryTtl, promiseDependency: Promise});
 
         key = support.random.string(20);
+        key2 = support.random.string(20);
         name = support.random.string();
+        name2 = support.random.string();
     });
 
-    describe("get(), set(), del(), reset()", function() {
+    describe("get(), set(), del(), reset(), mget(), mset()", function() {
         var value;
+        var value2;
 
         beforeEach(function() {
             multiCache = multiCaching([memoryCache, memoryCache2, memoryCache3]);
             key = support.random.string(20);
+            key2 = support.random.string(20);
             value = support.random.string();
+            value2 = support.random.string();
         });
 
         describe("set()", function() {
@@ -151,6 +163,120 @@ describe("multiCaching", function() {
             });
         });
 
+        describe("mset()", function() {
+            it("lets us set data in all caches", function(done) {
+                multiCache.mset(key, value, key2, value2, {ttl: defaultTtl}, function(err) {
+                    checkErr(err);
+
+                    memoryCache.mget(key, key2, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+
+                        memoryCache2.mget(key, key2, function(err, result) {
+                            checkErr(err);
+                            assert.equal(result[0], value);
+                            assert.equal(result[1], value2);
+
+                            memoryCache3.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.equal(result[0], value);
+                                assert.equal(result[1], value2);
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+
+            it("lets us set data without a callback", function(done) {
+                multiCache.mset(key, value, key2, value2, {ttl: defaultTtl});
+                setTimeout(function() {
+                    multiCache.mget(key, key2, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+
+                        memoryCache.mget(key, key2, function(err, result) {
+                            checkErr(err);
+                            assert.equal(result[0], value);
+                            assert.equal(result[1], value2);
+
+                            memoryCache2.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.equal(result[0], value);
+                                assert.equal(result[1], value2);
+
+                                memoryCache3.mget(key, key2, function(err, result) {
+                                    checkErr(err);
+                                    assert.equal(result[0], value);
+                                    assert.equal(result[1], value2);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                }, 20);
+            });
+
+            it("lets us set data without an options param", function(done) {
+                multiCache.mset(key, value, key2, value2, function(err) {
+                    checkErr(err);
+
+                    multiCache.mget(key, key2, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+
+                        memoryCache.mget(key, key2, function(err, result) {
+                            checkErr(err);
+                            assert.equal(result[0], value);
+                            assert.equal(result[1], value2);
+
+                            memoryCache2.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.equal(result[0], value);
+                                assert.equal(result[1], value2);
+
+                                memoryCache3.mget(key, key2, function(err, result) {
+                                    checkErr(err);
+                                    assert.equal(result[0], value);
+                                    assert.equal(result[1], value2);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+
+            it("lets us set data without options or callback", function(done) {
+                multiCache.set(key, value);
+                setTimeout(function() {
+                    multiCache.get(key, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result, value);
+
+                        memoryCache.get(key, function(err, result) {
+                            checkErr(err);
+                            assert.equal(result, value);
+
+                            memoryCache2.get(key, function(err, result) {
+                                checkErr(err);
+                                assert.equal(result, value);
+
+                                memoryCache3.get(key, function(err, result) {
+                                    checkErr(err);
+                                    assert.equal(result, value);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                }, 20);
+            });
+        });
+
         describe("get()", function() {
             it("gets data from first cache that has it", function(done) {
                 memoryCache3.set(key, value, function(err) {
@@ -215,6 +341,107 @@ describe("multiCaching", function() {
             });
         });
 
+        describe("mget()", function() {
+            it("gets data from first cache that has it (1)", function(done) {
+                memoryCache3.mset(key, value, key2, value2, function(err) {
+                    checkErr(err);
+
+                    multiCache.mget(key, key2, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+                        done();
+                    });
+                });
+            });
+
+            it("gets data from first cache that has it (2)", function(done) {
+                var key3 = support.random.string(20);
+                var value3 = support.random.string();
+                memoryCache.mset(key3, value3);
+                memoryCache2.mset(key, value);
+                memoryCache3.mset(key2, value2);
+
+                setTimeout(function() {
+                    multiCache.mget(key, key2, key3, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+                        assert.equal(result[2], value3);
+                        done();
+                    });
+                }, 20);
+            });
+
+            it("gets data from first cache that has it (3)", function(done) {
+                var key3 = support.random.string(20);
+                memoryCache2.mset(key, value);
+
+                setTimeout(function() {
+                    multiCache.mget(key2, key, key3, function(err, result) {
+                        checkErr(err);
+                        assert.equal(result[0], null);
+                        assert.equal(result[1], value);
+                        assert.equal(result[2], null);
+                        done();
+                    });
+                }, 20);
+            });
+
+            it("passes any options to underlying caches", function(done) {
+                multiCache.mset(key, value, key2, value2, function(err) {
+                    checkErr(err);
+
+                    sinon.spy(memoryCache.store, 'mget');
+
+                    var opts = {foo: 'bar'};
+
+                    multiCache.mget(key, key2, opts, function(err, result) {
+                        checkErr(err);
+
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+                        assert.ok(memoryCache.store.mget.calledWith(key, key2, opts));
+
+                        memoryCache.store.mget.restore();
+                        done();
+                    });
+                });
+            });
+
+            describe('using promises', function() {
+                it('gets data from first cache that has it', function(done) {
+                    memoryCache3.mset(key, value, key2, value2)
+                    .then(function() {
+                        return multiCache.mget(key, key2);
+                    })
+                    .then(function(result) {
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+                    })
+                    .then(done);
+                });
+
+                it("passes any options to underlying caches", function(done) {
+                    var opts = {foo: 'bar'};
+
+                    multiCache.mset(key, value, key2, value2)
+                    .then(function() {
+                        sinon.spy(memoryCache.store, 'mget');
+                        return multiCache.mget(key, key2, opts);
+                    })
+                    .then(function(result) {
+                        assert.equal(result[0], value);
+                        assert.equal(result[1], value2);
+                        assert.ok(memoryCache.store.mget.calledWith(key, key2, opts));
+
+                        memoryCache.store.mget.restore();
+                    })
+                    .then(done);
+                });
+            });
+        });
+
         describe("del()", function() {
             it("lets us delete data in all caches", function(done) {
                 multiCache.set(key, value, function(err) {
@@ -233,6 +460,62 @@ describe("multiCaching", function() {
                                 memoryCache3.get(key, function(err, result) {
                                     checkErr(err);
                                     assert.ok(!result);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+
+            it("lets us delete multiple keys in all caches (Args)", function(done) {
+                multiCache.mset(key, value, key2, value2, function(err) {
+                    checkErr(err);
+
+                    multiCache.del(key, key2, function(err) {
+                        checkErr(err);
+
+                        memoryCache.mget(key, key2, function(err, result) {
+                            assert.ok(!result[0]);
+                            assert.ok(!result[1]);
+
+                            memoryCache2.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.ok(!result[0]);
+                                assert.ok(!result[1]);
+
+                                memoryCache3.mget(key, key2, function(err, result) {
+                                    checkErr(err);
+                                    assert.ok(!result[0]);
+                                    assert.ok(!result[1]);
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+
+            it("lets us delete multiple keys in all caches (Array)", function(done) {
+                multiCache.mset(key, value, key2, value2, function(err) {
+                    checkErr(err);
+
+                    multiCache.del([key, key2], function(err) {
+                        checkErr(err);
+
+                        memoryCache.mget(key, key2, function(err, result) {
+                            assert.ok(!result[0]);
+                            assert.ok(!result[1]);
+
+                            memoryCache2.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.ok(!result[0]);
+                                assert.ok(!result[1]);
+
+                                memoryCache3.mget(key, key2, function(err, result) {
+                                    checkErr(err);
+                                    assert.ok(!result[0]);
+                                    assert.ok(!result[1]);
                                     done();
                                 });
                             });
@@ -457,10 +740,12 @@ describe("multiCaching", function() {
             context("calls back with the result of a function", function() {
                 beforeEach(function() {
                     sinon.spy(memoryCache3.store, 'set');
+                    sinon.spy(memoryCache3.store, 'mset');
                 });
 
                 afterEach(function() {
                     memoryCache3.store.set.restore();
+                    memoryCache3.store.mset.restore();
                 });
 
                 /**
@@ -470,10 +755,10 @@ describe("multiCaching", function() {
                 it('when a ttl number is passed in', function(done) {
                     multiCache.wrap(key, function(cb) {
                         methods.getWidget(name, cb);
-                    }, defaultTtl, function(err, widget) {
+                    }, {ttl: defaultTtl}, function(err, widget) {
                         checkErr(err);
                         assert.deepEqual(widget, {name: name});
-                        sinon.assert.calledWith(memoryCache3.store.set, key, {name: name}, defaultTtl);
+                        sinon.assert.calledWith(memoryCache3.store.set, key, {name: name}, {ttl: defaultTtl});
                         done();
                     });
                 });
@@ -497,6 +782,18 @@ describe("multiCaching", function() {
                         checkErr(err);
                         assert.deepEqual(widget, {name: name});
                         sinon.assert.calledWith(memoryCache3.store.set, key, {name: name});
+                        done();
+                    });
+                });
+
+                it('when multiple keys are passed', function(done) {
+                    multiCache.wrap(key, key2, function(cb) {
+                        methods.getMultiWidget([name, name2], cb);
+                    }, function(err, widgets) {
+                        checkErr(err);
+                        assert.deepEqual(widgets[0], {name: name});
+                        assert.deepEqual(widgets[1], {name: name2});
+                        sinon.assert.calledWith(memoryCache3.store.mset, key, {name: name}, key2, {name: name2});
                         done();
                     });
                 });
@@ -759,6 +1056,22 @@ describe("multiCaching", function() {
                     });
                 });
             });
+
+            context("when wrapped function does not return results", function() {
+                it("should not call 'setInMultipleCaches()'", function(done) {
+                    sinon.spy(memoryCache3.store, 'mset');
+
+                    multiCache.wrap(key, key2, function(cb) {
+                        cb(null, [undefined, undefined]);
+                    }, function(err, widgets) {
+                        checkErr(err);
+                        assert.ok(widgets === undefined);
+                        sinon.assert.notCalled(memoryCache3.store.mset);
+                        memoryCache3.store.mset.restore();
+                        done();
+                    });
+                });
+            });
         });
 
         describe("using two cache stores", function() {
@@ -815,6 +1128,27 @@ describe("multiCaching", function() {
                         });
                     });
                 });
+
+                it("returns value from first store, does not set it in second (multiple keys)", function(done) {
+                    memoryCache.mset(key, {name: name}, key2, {name: name2}, function(err) {
+                        checkErr(err);
+
+                        multiCache.wrap(key, key2, function(cb) {
+                            methods.getMultiWidget([name, name2], cb);
+                        }, function(err, widgets) {
+                            checkErr(err);
+                            assert.deepEqual(widgets[0], {name: name});
+                            assert.deepEqual(widgets[1], {name: name2});
+
+                            memoryCache3.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.equal(result[0], null);
+                                assert.equal(result[1], null);
+                                done();
+                            });
+                        });
+                    });
+                });
             });
 
             context("when value exists in second store but not first", function() {
@@ -831,6 +1165,27 @@ describe("multiCaching", function() {
                             memoryCache.get(key, function(err, result) {
                                 checkErr(err);
                                 assert.deepEqual(result, {name: name});
+                                done();
+                            });
+                        });
+                    });
+                });
+
+                it("returns value from second store, sets it in first store (multiple keys)", function(done) {
+                    memoryCache3.mset(key, {name: name}, key2, {name: name2}, function(err) {
+                        checkErr(err);
+
+                        multiCache.wrap(key, key2, function(cb) {
+                            methods.getMultiWidget([name, name2], cb);
+                        }, function(err, widgets) {
+                            checkErr(err);
+                            assert.deepEqual(widgets[0], {name: name});
+                            assert.deepEqual(widgets[1], {name: name2});
+
+                            memoryCache.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.deepEqual(result[0], {name: name});
+                                assert.deepEqual(result[1], {name: name2});
                                 done();
                             });
                         });
@@ -981,6 +1336,50 @@ describe("multiCaching", function() {
                     });
                 });
             });
+
+            describe("passing multiple keys", function() {
+                it("sets value in all caches", function(done) {
+                    multiCache.wrap(key, key2, function(cb) {
+                        methods.getMultiWidget([name, name2], cb);
+                    }, function(err, widgets) {
+                        checkErr(err);
+                        assert.deepEqual(widgets[0], {name: name});
+                        assert.deepEqual(widgets[1], {name: name2});
+
+                        memoryCache.mget(key, key2, function(err, result) {
+                            checkErr(err);
+                            assert.deepEqual(result[0], {name: name});
+                            assert.deepEqual(result[1], {name: name2});
+
+                            memoryCache2.mget(key, key2, function(err, result) {
+                                checkErr(err);
+                                assert.deepEqual(result[0], {name: name});
+                                assert.deepEqual(result[1], {name: name2});
+
+                                memoryCache3.mget(key, key2, function(err, result) {
+                                    checkErr(err);
+                                    assert.deepEqual(result[0], {name: name});
+                                    assert.deepEqual(result[1], {name: name2});
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+
+                it("should not throw error if one of the store does not have `mset() or mget()`", function(done) {
+                    var basicStore = {
+                        set: function() {},
+                        get: function() {}
+                    };
+                    sinon.spy(basicStore, 'set');
+                    multiCache = multiCaching([memoryCache, {store: basicStore}]);
+
+                    multiCache.wrap(key, key2, function(cb) {
+                        methods.getMultiWidget([name, name2], cb);
+                    }, done);
+                });
+            });
         });
 
         context("error handling", function() {
@@ -1034,7 +1433,7 @@ describe("multiCaching", function() {
                 it("bubbles up that error", function(done) {
                     multiCache.wrap(key, function(next) {
                         next();
-                    }, ttl, function() {
+                    }, {ttl: ttl}, function() {
                         // This test as-is doesn't prove a fix for #28 (https://github.com/BryanDonovan/node-cache-manager/issues/28)
                         // but if you remove the try/catch, it shows that the undefined `waiting` array issue
                         // is no longer present (the domain doesn't try to process the error in the callbackFiller).
@@ -1044,6 +1443,15 @@ describe("multiCaching", function() {
                             assert.equal(e.message, 'foo');
                         }
 
+                        done();
+                    });
+                });
+
+                it("bubbles up that error (multiple keys)", function(done) {
+                    multiCache.wrap(key, key2, function(next) {
+                        next(fakeError);
+                    }, {ttl: ttl}, function(err) {
+                        assert.equal(err, fakeError);
                         done();
                     });
                 });
@@ -1080,10 +1488,27 @@ describe("multiCaching", function() {
                     });
                 });
             });
+
+            context("when store.mget() calls back with an error", function() {
+                it("bubbles up that error", function(done) {
+                    var fakeError = new Error(support.random.string());
+
+                    sinon.stub(memoryStoreStub, 'mget').yields(fakeError);
+
+                    multiCache.wrap(key, key2, function(cb) {
+                        methods.getMultiWidget([name, name2], cb);
+                    }, function(err) {
+                        assert.equal(err, fakeError);
+                        memoryStoreStub.mget.restore();
+                        done();
+                    });
+                });
+            });
         });
 
         describe("when called multiple times in parallel with same key", function() {
             var construct;
+            var constructMulti;
 
             beforeEach(function() {
                 multiCache = multiCaching([memoryCache, memoryCache3]);
@@ -1105,6 +1530,13 @@ describe("multiCaching", function() {
                         cb(null, 'value');
                     }, timeout);
                 });
+
+                constructMulti = sinon.spy(function(val, cb) {
+                    var timeout = getTimeout();
+                    setTimeout(function() {
+                        cb(null, ['value', 'value2']);
+                    }, timeout);
+                });
             });
 
             it("calls the wrapped function once", function(done) {
@@ -1123,6 +1555,27 @@ describe("multiCaching", function() {
                 }, function(err) {
                     checkErr(err);
                     assert.equal(construct.callCount, 1);
+                    done();
+                });
+            });
+
+            it("calls the multi wrapped function once", function(done) {
+                var values = [];
+                for (var i = 0; i < 5; i++) {
+                    values.push(i);
+                }
+
+                async.each(values, function(val, next) {
+                    multiCache.wrap('key', 'key2', function(cb) {
+                        constructMulti(val, cb);
+                    }, function(err, results) {
+                        assert.equal(results[0], 'value');
+                        assert.equal(results[1], 'value2');
+                        next(err);
+                    });
+                }, function(err) {
+                    checkErr(err);
+                    assert.equal(constructMulti.callCount, 1);
                     done();
                 });
             });

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -1,0 +1,25 @@
+
+var utils = require('../lib/utils');
+var assert = require('assert');
+
+var isObject = utils.isObject;
+
+describe('utils', function() {
+    describe('isObject()', function() {
+        it('should return "true" when value passed is an object', function() {
+            var result1 = isObject({});
+            assert.ok(result1);
+        });
+
+        it('should return "false" when value passed is not an object', function() {
+            var result1 = isObject('string');
+            var result2 = isObject(123);
+            var result3 = isObject([]);
+            var result4 = isObject(function() {});
+            assert.ok(!result1);
+            assert.ok(!result2);
+            assert.ok(!result3);
+            assert.ok(!result4);
+        });
+    });
+});


### PR DESCRIPTION
Hello!

This PR is to allow setting, getting and deleting multiple keys at once. It works both on the caching and the multicaching. As such, the "wrap" method now accepts an unlimited number of keys.

I am aware that this is a big feature with loads of changes. I had to do some refactoring to stay under the cyclomatic complexity. Let me know all your comments.

This feature does not add any breaking change to node-cache-manager.

I opened a PR in "node-cache-manager-redis-store" to give support to this feature in redis store (https://github.com/dabroek/node-cache-manager-redis-store/pull/6)