### PR TITLE
fix(multi_caching): getFromHighestProrityCache()

### DIFF
--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -172,7 +172,7 @@ var multiCaching = function(caches, options) {
                     mapResult[key] = res;
 
                     // delete key from our keysToFetch array
-                    keysToFetch.splice(i, 1);
+                    keysToFetch.splice(i - diff, 1);
                     diff += 1;
                 }
             });


### PR DESCRIPTION
The "keysToFetch" in getFromHighestProrityCache() was not being emptied causing the fetch to go through all the caches even though the result had been found.