### PR TITLE
Updated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "Bryan Donovan",
   "license": "MIT",
   "dependencies": {
-    "async": "1.5.2",
-    "lru-cache": "4.0.0"
+    "async": "2.6.0",
+    "lru-cache": "4.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.3.0",


### PR DESCRIPTION
only .each and .eachSeries are used from async, and I don't see braking changes introduced between 1.5.2 and 2.6.0 in those methods