### PR TITLE
Don't brake store's this context for isCacheableValue method

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -38,7 +38,7 @@ var caching = function(args) {
     if (typeof args.isCacheableValue === 'function') {
         self._isCacheableValue = args.isCacheableValue;
     } else if (typeof self.store.isCacheableValue === 'function') {
-        self._isCacheableValue = self.store.isCacheableValue;
+        self._isCacheableValue = self.store.isCacheableValue.bind(self.store);
     } else {
         self._isCacheableValue = function(value) {
             return value !== undefined;

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -1234,4 +1234,22 @@ describe("caching", function() {
             });
         });
     });
+
+    describe("when using store's isCacheableValue method", function() {
+        it("should not break its' context", function() {
+            var store = {
+                isCacheableValue: function() {
+                    if (this !== store) {
+                        throw new Error("Broken store context");
+                    }
+                },
+                get: function() {},
+                set: function() {},
+            };
+
+            cache = caching({store: store});
+
+            assert.doesNotThrow(cache._isCacheableValue);
+        });
+    });
 });


### PR DESCRIPTION
Using `cache-manager-memcached-store` store's `isCacheableValue` method will fail because when caching assigns the value to `self._isCacheableValue` it does not pass the `this` context.

This PR takes care that store's context is passed to `isCacheableValue`.