### PR TITLE
Add .js to module path to fix compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	./node_modules/.bin/jscs ./test && \
 	./node_modules/.bin/jscs ./examples && \
 	./node_modules/.bin/jshint ./lib --config $(BASE)/.jshintrc && \
-	./node_modules/.bin/jshint ./test --config $(BASE)/.jshintrc
+	./node_modules/.bin/jshint ./test --config $(BASE)/.jshintrc && \
 	./node_modules/.bin/jshint ./examples --config $(BASE)/.jshintrc
 
 docs:

--- a/README.md
+++ b/README.md
@@ -184,7 +184,20 @@ memoryCache.wrap(key, function(cb) {
 }
 ```
 
-You can get several keys at once. E.g.
+You can get several keys at once. Note that this will return whatever records it
+finds in the cache and it is up to the user to check the results against the
+supplied keys and make any calls to the underlying data store to fill in
+missing records. In practice, this should not be much of a concern if you are
+only using the `wrap` function to set these records in cache.
+
+Side note: Ideally the `wrap` function would get what it can from the cache and fill in
+the missing records from the data store, but I can't think of a way to do this
+that is generic to all situations.  Another option is to only return the data
+from the cache if all records are found, but this woul break multi-caching.
+
+See unit tests in `caching.unit.js` for more information.
+
+Example:
 
 ```js
 

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -25,7 +25,7 @@ var caching = function(args) {
         }
     } else {
         var storeName = args.store || 'memory';
-        self.store = require('./stores/' + storeName).create(args);
+        self.store = require('./stores/' + storeName + '.js').create(args);
     }
 
     // do we handle a cache error the same as a cache miss?

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -185,16 +185,16 @@ var caching = function(args) {
             * are valid. If one or more of the values is not cacheable
             * the cache result is not valid.
             */
-            var cacheOK = Array.isArray(result) && result.filter(function(_result) {
+            var cacheOk = Array.isArray(result) && result.filter(function(_result) {
                 return self._isCacheableValue(_result);
             }).length === result.length;
 
-            if (cacheOK) {
+            if (cacheOk) {
                 return callbackFiller.fill(combinedKey, null, result);
             }
 
             return work(function(err, data) {
-                if (err) {
+                if (err || !data) {
                     return done(err);
                 }
 


### PR DESCRIPTION
Hi there 👋This is a small change that allows compilers like [`@zeit/ncc`](https://github.com/zeit/ncc) to properly work with `cache-manager`. 🙂

This fix [would allow us](https://github.com/imjohnbo/cache-manager-zeit-ncc/blob/8f69d40275240079d9acd31de846095640e91f1f/package.json) to use `ncc` to compile [`probot`](https://github.com/probot/probot), a downstream user of `cache-manager`. The tracking issue for this compilation error is [here](https://github.com/zeit/ncc/issues/480).

Thanks for taking a look! 🙏