### PR TITLE
adding way to disable cloning of values in memory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ var cacheManager = require('cache-manager');
 var memoryCache = cacheManager.caching({store: 'memory', max: 100, ttl: 10/*seconds*/});
 var ttl = 5;
 // Note: callback is optional in set() and del().
+// Note: memory cache clones values before setting them unless
+// shouldCloneBeforeSet is set to false
 
 memoryCache.set('foo', 'bar', {ttl: ttl}, function(err) {
     if (err) { throw err; }

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -11,12 +11,24 @@ function clone(object) {
     return object;
 }
 
+/**
+ * Wrapper for lru-cache.
+ * NOTE: If you want to use a memory store, you want to write your own to have full
+ * control over its behavior.  E.g., you might need the extra Promise overhead or
+ * you may want to clone objects a certain way before storing.
+ *
+ * @param {object} args - Args passed to underlying lru-cache, plus additional optional args:
+ * @param {boolean} [args.shouldCloneBeforeSet=true] - Whether to clone the data being stored.
+ *   Default: true
+ * @param {boolean} [args.usePromises=true] - Whether to enable the use of Promises. Default: true
+ */
 var memoryStore = function(args) {
     args = args || {};
     var self = {};
     self.name = 'memory';
     var Promise = args.promiseDependency || global.Promise;
-    self.usePromises = !((typeof Promise === 'undefined' || args.noPromises));
+    self.usePromises = !(typeof Promise === 'undefined' || args.noPromises);
+    self.shouldCloneBeforeSet = args.shouldCloneBeforeSet !== false; // clone by default
 
     var ttl = args.ttl;
     var lruOpts = {
@@ -40,7 +52,9 @@ var memoryStore = function(args) {
     };
 
     self.set = function(key, value, options, cb) {
-        value = clone(value);
+        if (self.shouldCloneBeforeSet) {
+            value = clone(value);
+        }
 
         if (typeof options === 'function') {
             cb = options;

--- a/test/stores/memory.unit.js
+++ b/test/stores/memory.unit.js
@@ -96,87 +96,177 @@ describe("memory store", function() {
                 assert.equal(result.f(), 'foo', 'prototype function f does not return expected value');
             }
 
-            beforeEach(function() {
-                cache = caching({store: 'memory', ttl: opts.ttl, ignoreCacheErrors: false});
-            });
+            // By default, memory store clones values before setting in the set method.
+            context("when shouldCloneBeforeSet option is not passed in", () => {
+                beforeEach(function() {
+                    cache = caching({store: 'memory', ttl: opts.ttl, ignoreCacheErrors: false});
+                });
 
-            it("does not allow mutation of objects", function(done) {
-                getCachedObject('foo', function(err, result) {
-                    checkErr(err);
-                    result.foo = 'buzz';
-
+                it("does not allow mutation of objects", function(done) {
                     getCachedObject('foo', function(err, result) {
                         checkErr(err);
-                        assert.equal(result.foo, 'bar');
-                        done();
+                        result.foo = 'buzz';
+
+                        getCachedObject('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result.foo, 'bar');
+                            done();
+                        });
                     });
                 });
-            });
 
-            it("does not allow mutation of arrays", function(done) {
-                getCachedArray('foo', function(err, result) {
-                    checkErr(err);
-                    assert.ok(result);
-                    result = ['a', 'b', 'c'];
-
+                it("does not allow mutation of arrays", function(done) {
                     getCachedArray('foo', function(err, result) {
                         checkErr(err);
-                        assert.deepEqual(result, [1, 2, 3]);
-                        done();
+                        assert.ok(result);
+                        result = ['a', 'b', 'c'];
+
+                        getCachedArray('foo', function(err, result) {
+                            checkErr(err);
+                            assert.deepEqual(result, [1, 2, 3]);
+                            done();
+                        });
                     });
                 });
-            });
 
-            it("does not allow mutation of strings", function(done) {
-                getCachedString('foo', function(err, result) {
-                    checkErr(err);
-                    assert.ok(result);
-                    result = 'buzz';
-
+                it("does not allow mutation of strings", function(done) {
                     getCachedString('foo', function(err, result) {
                         checkErr(err);
-                        assert.equal(result, 'bar');
-                        done();
+                        assert.ok(result);
+                        result = 'buzz';
+
+                        getCachedString('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result, 'bar');
+                            done();
+                        });
                     });
                 });
-            });
 
-            it("does not allow mutation of numbers", function(done) {
-                getCachedNumber('foo', function(err, result) {
-                    checkErr(err);
-                    assert.ok(result);
-                    result = 12;
-
+                it("does not allow mutation of numbers", function(done) {
                     getCachedNumber('foo', function(err, result) {
                         checkErr(err);
-                        assert.equal(result, 34);
-                        done();
+                        assert.ok(result);
+                        result = 12;
+
+                        getCachedNumber('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result, 34);
+                            done();
+                        });
                     });
                 });
-            });
 
-            it("preserves functions", function(done) {
-                getCachedFunction('foo', function(err, result) {
-                    checkErr(err);
-                    assert.equal(typeof result, 'function');
-
+                it("preserves functions", function(done) {
                     getCachedFunction('foo', function(err, result) {
                         checkErr(err);
                         assert.equal(typeof result, 'function');
-                        done();
+
+                        getCachedFunction('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(typeof result, 'function');
+                            done();
+                        });
+                    });
+                });
+
+                it("preserves object prototype", function(done) {
+                    getCachedObjectWithPrototype('foo', function(err, result) {
+                        checkErr(err);
+                        assertCachedObjectWithPrototype(result);
+
+                        getCachedObjectWithPrototype('foo', function(err, result) {
+                            checkErr(err);
+                            assertCachedObjectWithPrototype(result);
+                            done();
+                        });
                     });
                 });
             });
 
-            it("preserves object prototype", function(done) {
-                getCachedObjectWithPrototype('foo', function(err, result) {
-                    checkErr(err);
-                    assertCachedObjectWithPrototype(result);
+            context("when shouldCloneBeforeSet=false option is passed in", () => {
+                beforeEach(function() {
+                    cache = caching({store: 'memory', ttl: opts.ttl, shouldCloneBeforeSet: false, ignoreCacheErrors: false});
+                });
 
+                it("*does* allow mutation of objects", function(done) {
+                    getCachedObject('foo', function(err, result) {
+                        checkErr(err);
+                        result.foo = 'buzz';
+
+                        getCachedObject('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result.foo, 'buzz');
+                            done();
+                        });
+                    });
+                });
+
+                it("does not allow mutation of arrays", function(done) {
+                    getCachedArray('foo', function(err, result) {
+                        checkErr(err);
+                        assert.ok(result);
+                        result = ['a', 'b', 'c'];
+
+                        getCachedArray('foo', function(err, result) {
+                            checkErr(err);
+                            assert.deepEqual(result, [1, 2, 3]);
+                            done();
+                        });
+                    });
+                });
+
+                it("does not allow mutation of strings", function(done) {
+                    getCachedString('foo', function(err, result) {
+                        checkErr(err);
+                        assert.ok(result);
+                        result = 'buzz';
+
+                        getCachedString('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result, 'bar');
+                            done();
+                        });
+                    });
+                });
+
+                it("does not allow mutation of numbers", function(done) {
+                    getCachedNumber('foo', function(err, result) {
+                        checkErr(err);
+                        assert.ok(result);
+                        result = 12;
+
+                        getCachedNumber('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(result, 34);
+                            done();
+                        });
+                    });
+                });
+
+                it("preserves functions", function(done) {
+                    getCachedFunction('foo', function(err, result) {
+                        checkErr(err);
+                        assert.equal(typeof result, 'function');
+
+                        getCachedFunction('foo', function(err, result) {
+                            checkErr(err);
+                            assert.equal(typeof result, 'function');
+                            done();
+                        });
+                    });
+                });
+
+                it("preserves object prototype", function(done) {
                     getCachedObjectWithPrototype('foo', function(err, result) {
                         checkErr(err);
                         assertCachedObjectWithPrototype(result);
-                        done();
+
+                        getCachedObjectWithPrototype('foo', function(err, result) {
+                            checkErr(err);
+                            assertCachedObjectWithPrototype(result);
+                            done();
+                        });
                     });
                 });
             });


### PR DESCRIPTION
This is to allow the user to choose whether the memory store clones values before storing them in cache (via the `set` method).  Related issues:

- https://github.com/BryanDonovan/node-cache-manager/issues/100
- https://github.com/BryanDonovan/node-cache-manager/pull/103
- https://github.com/BryanDonovan/node-cache-manager/issues/132
- https://github.com/BryanDonovan/node-cache-manager/issues/134

I'm trying to decide if this change warrants a major version bump.  It makes sense to do a major bump in the sense that anyone using version 2.10.1 or earlier could run into issues with 2.10.2, 2.11.0, or 2.11.1, and the new version.  So maybe a clean break is good.  On the other hand, the new changes work the same as 2.11.1, so in that sense it's a minor bump.
