### PR TITLE
Added the updateAgeOnGet option

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -36,7 +36,8 @@ var memoryStore = function(args) {
         maxAge: (ttl || ttl === 0) ? ttl * 1000 : null,
         dispose: args.dispose,
         length: args.length,
-        stale: args.stale
+        stale: args.stale,
+        updateAgeOnGet: args.updateAgeOnGet || false
     };
 
     var lruCache = new Lru(lruOpts);


### PR DESCRIPTION
As requsted by #122, updateAgeOnGet can now be set as a args attribute when calling cacheManager.caching(). Default is false, as is in  [lru-cache](https://github.com/isaacs/node-lru-cache/blob/master/index.js).