### PR TITLE
Background refresh of expiring entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,14 @@ Both the `caching` and `multicaching` modules support a mechanism to refresh exp
 This is done by adding a `refreshThreshold` attribute while creating the caching store.
 
 If `refreshThreshold` is set and if the `ttl` method is available for the used store, after retrieving a value from cache TTL will be checked.
-If the remaining TTL is less than `refreshThreshold`, the system will spawn a background worker to update the value, following same rules as standard fetching. In case of multicaching, the value will be then updated in all the stores. In the meantime, the system will return the old value until expiration (or update).
+If the remaining TTL is less than `refreshThreshold`, the system will spawn a background worker to update the value, following same rules as standard fetching. In the meantime, the system will return the old value until expiration.
+
+In case of multicaching, the store that will be used for refresh is the one where the key will be found first (highest priority). The value will then be set in all the stores.
 
 NOTES:
 
+* In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).
+* If the threshold is low and the worker function is slow, the key may expire and you may encounter a racing condition with updating values.
 * The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
 * The caching store needs to provide the `ttl` method.
 

--- a/README.md
+++ b/README.md
@@ -448,10 +448,10 @@ For example, pass the refreshThreshold to `caching` like this:
 ```javascript
 var redisStore = require('cache-manager-ioredis');
 
-var memoryCache = cacheManager.caching({store: redisStore, refreshThreshold: 3, isCacheableValue: isCacheableValue});
+var redisCache = cacheManager.caching({store: redisStore, refreshThreshold: 3, isCacheableValue: isCacheableValue});
 ```
 
-When a value will be retrieved from Redis with a TTL minor than 3sec, the value will be updated in background.
+When a value will be retrieved from Redis with a remaining TTL < 3sec, the value will be updated in background.
 
 ### Development environment
 You may disable real caching but still get all the callback functionality working by setting `none` store.

--- a/README.md
+++ b/README.md
@@ -426,6 +426,29 @@ var multiCache = cacheManager.multiCaching([memoryCache, someOtherCache], {
 
 ```
 
+### Refresh cache keys in background
+
+Both the `caching` and `multicaching` modules support a mechanism to refresh expiring cache keys in background when using `wrap` function.
+This is done by adding a `refreshThreshold` attribute while creating the caching store.
+
+If `refreshThreshold` is set and if the `ttl` method is available for the used store, after retrieving a value from cache TTL will be checked.
+If the remaining TTL is less than `refreshThreshold`, the system will spawn a background worker to update the value, following same rules as standard fetching. In case of multicaching, the value will be then updated in all the stores. In the meantime, the system will return the old value until expiration (or update).
+
+NOTES:
+
+* The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
+* The caching store needs to provide the `ttl` method.
+
+For example, pass the refreshThreshold to `caching` like this:
+
+```javascript
+var redisStore = require('cache-manager-ioredis');
+
+var memoryCache = cacheManager.caching({store: redisStore, refreshThreshold: 3, isCacheableValue: isCacheableValue});
+```
+
+When a value will be retrieved from Redis with a TTL minor than 3sec, the value will be updated in background.
+
 ### Development environment
 You may disable real caching but still get all the callback functionality working by setting `none` store.
 

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -99,9 +99,9 @@ var caching = function(args) {
      * In all other cases this method callbacks will contain "false" (ie. not expiring).
      *
      * @function
-     * @name isExpiring
+     * @name checkRefreshThreshold
      *
-     * @param {string} key - The cache key to use in cache operations.
+     * @param {string} key - The cache key to check.
      * @param {function} cb
      *
      */

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -30,10 +30,12 @@ var caching = function(args) {
 
     // do we handle a cache error the same as a cache miss?
     self.ignoreCacheErrors = args.ignoreCacheErrors || false;
+    self.refreshThreshold = args.refreshThreshold || false;
 
     var Promise = args.promiseDependency || global.Promise;
 
     var callbackFiller = new CallbackFiller();
+    var backgroundQueue = new Set();
 
     if (typeof args.isCacheableValue === 'function') {
         self._isCacheableValue = args.isCacheableValue;
@@ -63,6 +65,58 @@ var caching = function(args) {
             });
         });
     }
+
+    function handleBackgroundRefresh(key, work, options) {
+        if (!backgroundQueue.has(key)) {
+            backgroundQueue.add(key);
+            self.checkRefreshThreshold(key, function(err, isExpiring) {
+                if (err) {
+                    backgroundQueue.delete(key);
+                    return;
+                }
+                if (isExpiring) {
+                    work(function(err, data) {
+                        if (err || !self._isCacheableValue(data)) {
+                            backgroundQueue.delete(key);
+                            return;
+                        }
+                        if (options && typeof options.ttl === 'function') {
+                            options.ttl = options.ttl(data);
+                        }
+                        self.store.set(key, data, options, function() {
+                            backgroundQueue.delete(key);
+                        });
+                    });
+                }
+            });
+        }
+    }
+
+    /**
+     * Checks if the current key is expiring. I.e., if a refreshThreshold is set for this cache
+     * and if the cache supports the ttl method, this methods theck if the remaining ttl is
+     * less than the refreshThreshold.
+     * In all other cases this method callbacks will contain "false" (ie. not expiring).
+     *
+     * @function
+     * @name isExpiring
+     *
+     * @param {string} key - The cache key to use in cache operations.
+     * @param {function} cb
+     *
+     */
+    self.checkRefreshThreshold = function(key, cb) {
+        if (self.refreshThreshold && typeof self.store.ttl === 'function') {
+            return self.store.ttl(key, function(ttlErr, ttl) {
+                if (self.refreshThreshold > ttl) {
+                    return cb(null, true);
+                }
+                return cb(null, false);
+            });
+        } else {
+            return cb(new Error('Unhandled refresh'));
+        }
+    };
 
     /**
      * Wraps a function in cache. I.e., the first time the function is run,
@@ -127,6 +181,7 @@ var caching = function(args) {
             if (err && (!self.ignoreCacheErrors)) {
                 callbackFiller.fill(key, err);
             } else if (self._isCacheableValue(result)) {
+                handleBackgroundRefresh(key, work, options);
                 callbackFiller.fill(key, null, result);
             } else {
                 work(function(err, data) {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -108,6 +108,9 @@ var caching = function(args) {
     self.checkRefreshThreshold = function(key, cb) {
         if (self.refreshThreshold && typeof self.store.ttl === 'function') {
             return self.store.ttl(key, function(ttlErr, ttl) {
+                if (ttlErr || typeof ttl !== 'number') {
+                    return cb(new Error('Invalid TTL response'));
+                }
                 if (self.refreshThreshold > ttl) {
                     return cb(null, true);
                 }

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -29,6 +29,7 @@ var multiCaching = function(caches, options) {
     }
 
     var callbackFiller = new CallbackFiller();
+    var backgroundQueue = new Set();
 
     if (typeof options.isCacheableValue === 'function') {
         self._isCacheableValue = options.isCacheableValue;
@@ -323,6 +324,34 @@ var multiCaching = function(caches, options) {
         });
     }
 
+    function handleBackgroundRefresh(caches, index, key, work) {
+        // handle background refetch
+        if (!backgroundQueue.has(key)) {
+            backgroundQueue.add(key);
+            caches[index].checkRefreshThreshold(key, function(err, isExpiring) {
+                if (err) {
+                    backgroundQueue.delete(key);
+                    return;
+                }
+                if (isExpiring) {
+                    work(function(workErr, workData) {
+                        if (workErr || !self._isCacheableValue(workData)) {
+                            backgroundQueue.delete(key);
+                            return;
+                        }
+                        if (options && typeof options.ttl === 'function') {
+                            options.ttl = options.ttl(workData);
+                        }
+                        var args = [caches, key, workData, options, function() {
+                            backgroundQueue.delete(key);
+                        }];
+                        setInMultipleCaches.apply(null, args);
+                    });
+                }
+            });
+        }
+    }
+
     /**
      * Wraps a function in one or more caches.
      * Has same API as regular caching module.
@@ -373,6 +402,7 @@ var multiCaching = function(caches, options) {
             if (err) {
                 return callbackFiller.fill(key, err);
             } else if (self._isCacheableValue(result)) {
+                handleBackgroundRefresh(caches, index, key, work);
                 var cachesToUpdate = caches.slice(0, index);
                 var args = [cachesToUpdate, key, result, options, function(err) {
                     callbackFiller.fill(key, err, result);


### PR DESCRIPTION
Fixes: #93 

This PR implements a mechanism to update the cached value in background by adding a new "refreshThreshold" configuration parameter for cache stores.

If `refreshThreshold` is set and if the `ttl(key)` method is available in the used store, after retrieving a value from cache the TTL of that entry will be checked.
If the remaining TTL is less than `refreshThreshold`, the system will spawn a background worker to update the value, following same rules as standard fetching. In case of multicaching, the value will be then updated in all the stores. In the meantime, the system will return the old value until expiration (or update).
In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).

NOTES:
* Background workers are put in a queue so that we avoid spawning multiple workers for the same key.
* If the `refreshThreshold` is low and the backend is slow, a racing condition may be encountered where the refresh is still. waiting to finish but at the same time a "standard" worker starts.
* The caching store needs to provide the `ttl` method (eg. standard memoryStore is not supported)
* The background refresh mechanism currently does not support providing multiple keys to `wrap` function. This is because I found it hard to find a sane way to handle this (also due to https://github.com/BryanDonovan/node-cache-manager/issues/130 )
* This flow is similar to `stale-while-revalidate` mechanism but works backwards: while in stale-while-revalidate a cache entry is kept *after* expiration for a specified period, this mechanism works *before* expiration in a specified interval. This is because otherwise we would have had to rewrite all stores to support this functionality.

Inspiration:
- https://github.com/raadad/node-cachemire
- https://github.com/cdhorne/node-cache-manager/pull/1