### PR TITLE
Background refresh fixes

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -67,7 +67,7 @@ var caching = function(args) {
     }
 
     function handleBackgroundRefresh(key, work, options) {
-        if (!backgroundQueue.has(key)) {
+        if (self.refreshThreshold && !backgroundQueue.has(key)) {
             backgroundQueue.add(key);
             self.checkRefreshThreshold(key, function(err, isExpiring) {
                 if (err) {
@@ -87,6 +87,8 @@ var caching = function(args) {
                             backgroundQueue.delete(key);
                         });
                     });
+                } else {
+                    backgroundQueue.delete(key);
                 }
             });
         }

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -338,9 +338,6 @@ var multiCaching = function(caches, options) {
                             backgroundQueue.delete(key);
                             return;
                         }
-                        if (options && typeof options.ttl === 'function') {
-                            options.ttl = options.ttl(workData);
-                        }
                         var args = [caches, key, workData, options, function() {
                             backgroundQueue.delete(key);
                         }];

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -324,7 +324,7 @@ var multiCaching = function(caches, options) {
         });
     }
 
-    function handleBackgroundRefresh(caches, index, key, work) {
+    function handleBackgroundRefresh(caches, index, key, work, options) {
         if (caches[index].refreshThreshold && !backgroundQueue.has(key)) {
             backgroundQueue.add(key);
             caches[index].checkRefreshThreshold(key, function(err, isExpiring) {
@@ -403,7 +403,7 @@ var multiCaching = function(caches, options) {
             if (err) {
                 return callbackFiller.fill(key, err);
             } else if (self._isCacheableValue(result)) {
-                handleBackgroundRefresh(caches, index, key, work);
+                handleBackgroundRefresh(caches, index, key, work, options);
                 var cachesToUpdate = caches.slice(0, index);
                 var args = [cachesToUpdate, key, result, options, function(err) {
                     callbackFiller.fill(key, err, result);

--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -325,7 +325,7 @@ var multiCaching = function(caches, options) {
     }
 
     function handleBackgroundRefresh(caches, index, key, work) {
-        if (!backgroundQueue.has(key)) {
+        if (caches[index].refreshThreshold && !backgroundQueue.has(key)) {
             backgroundQueue.add(key);
             caches[index].checkRefreshThreshold(key, function(err, isExpiring) {
                 if (err) {
@@ -346,6 +346,8 @@ var multiCaching = function(caches, options) {
                         }];
                         setInMultipleCaches.apply(null, args);
                     });
+                } else {
+                    backgroundQueue.delete(key);
                 }
             });
         }

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -1105,7 +1105,7 @@ describe("caching", function() {
             });
         });
 
-        describe("using tweaked memory (lru-cache) store with a refreshThreshold", function() {
+        describe("using memory (lru-cache) store with a refreshThreshold", function() {
             var memoryStoreStub;
             var opts;
 
@@ -1124,13 +1124,52 @@ describe("caching", function() {
                 memoryStore.create.restore();
             });
 
-            context("when result is already cached", function() {
-                function getCachedWidget(name, cb) {
-                    cache.wrap(key, function(cacheCb) {
-                        methods.getWidget(name, cacheCb);
-                    }, opts, cb);
-                }
+            function getCachedWidget(name, cb) {
+                cache.wrap(key, function(cacheCb) {
+                    methods.getWidget(name, cacheCb);
+                }, opts, cb);
+            }
 
+            context("using standard memorystore", function() {
+                beforeEach(function(done) {
+                    getCachedWidget(name, function(err, widget) {
+                        checkErr(err);
+                        assert.ok(widget);
+
+                        memoryStoreStub.get(key, function(err, result) {
+                            checkErr(err);
+                            assert.ok(result);
+
+                            sinon.spy(cache, 'checkRefreshThreshold');
+                            done();
+                        });
+                    });
+                });
+
+                afterEach(function() {
+                    cache.checkRefreshThreshold.restore();
+                });
+
+                it("retrieves data from cache and stops background if failing while checking ttl", function(done) {
+                    // NOTE: TTL function is not defined
+                    var funcCalled = false;
+                    cache.wrap(key, function(cb) {
+                        funcCalled = true;
+                        methods.getWidget(name, function(err, result) {
+                            cb(err, result);
+                        });
+                    }, function(err, widget) {
+                        checkErr(err);
+                        assert.deepEqual(widget, {name: name});
+                        assert.equal(cache.checkRefreshThreshold.callCount, 1);
+                        assert.equal(funcCalled, false);
+
+                        done();
+                    });
+                });
+            });
+
+            context("using tweaked memory store, when result is already cached", function() {
                 beforeEach(function(done) {
                     memoryStoreStub.ttl = function(key, cb) {
                         return cb(null, 5);
@@ -1175,15 +1214,41 @@ describe("caching", function() {
                         done();
                     });
                 });
+
+                it("retrieves data from cache and checks twice ttl without refreshing", function(done) {
+                    var funcCalled = 0;
+                    var values = [];
+
+                    for (var i = 0; i < 2; i++) {
+                        values.push(i);
+                    }
+
+                    async.eachSeries(values, function(val, next) {
+                        cache.wrap(key, function(cb) {
+                            funcCalled += 1;
+                            methods.getWidget(name, function(err, result) {
+                                cb(err, result);
+                            });
+                        }, function(err, widget) {
+                            checkErr(err);
+                            assert.deepEqual(widget, {name: name});
+                            next(err);
+                        });
+                    }, function(err) {
+                        // Wait for just a bit, to be sure that the callback is called.
+                        setTimeout(function() {
+                            checkErr(err);
+                            assert.equal(memoryStoreStub.get.callCount, 2);
+                            assert.equal(memoryStoreStub.ttl.callCount, 2);
+                            assert.equal(funcCalled, 0);
+                            assert.equal(memoryStoreStub.set.callCount, 0);
+                            done();
+                        }, 500);
+                    });
+                });
             });
 
-            context("when result is already cached but expiring", function() {
-                function getCachedWidget(name, cb) {
-                    cache.wrap(key, function(cacheCb) {
-                        methods.getWidget(name, cacheCb);
-                    }, opts, cb);
-                }
-
+            context("using tweaked memorystore, when result is already cached but expiring", function() {
                 beforeEach(function(done) {
                     memoryStoreStub.ttl = function(key, cb) {
                         return cb(null, 1);

--- a/test/caching.unit.js
+++ b/test/caching.unit.js
@@ -1298,6 +1298,34 @@ describe("caching", function() {
                     });
                 });
 
+                it("returns value and invokes worker in background using the provided ttl function", function(done) {
+                    var funcCalled = false;
+                    var ttlFuncCalled = false;
+                    var ttlFunc = function() {
+                        ttlFuncCalled = true;
+                        return 4;
+                    };
+
+                    cache.wrap(key, function(cb) {
+                        funcCalled = true;
+                        methods.getWidget(name, function(err, result) {
+                            cb(err, result);
+                        });
+                    }, {ttl: ttlFunc}, function(err, widget) {
+                        // Wait for just a bit, to be sure that the callback is called.
+                        setTimeout(function() {
+                            checkErr(err);
+                            assert.deepEqual(widget, {name: name});
+                            assert.ok(memoryStoreStub.get.calledWith(key));
+                            assert.ok(memoryStoreStub.ttl.calledWith(key));
+                            assert.equal(funcCalled, true);
+                            assert.equal(ttlFuncCalled, true);
+                            assert.equal(memoryStoreStub.set.callCount, 1);
+                            done();
+                        }, 500);
+                    });
+                });
+
                 it("returns value and invokes worker in background once when called multiple times", function(done) {
                     var funcCalled = 0;
                     var values = [];

--- a/test/multi_caching.unit.js
+++ b/test/multi_caching.unit.js
@@ -1375,6 +1375,30 @@ describe("multiCaching", function() {
                         }, 500);
                     });
                 });
+
+                it('returns value and invokes worker in background using the provided TTL function', function(done) {
+                    var funcCalled = false;
+                    var ttlFuncCalled = false;
+                    var ttlFunc = function() {
+                        ttlFuncCalled = true;
+                        return 4;
+                    };
+                    multiCache.wrap(key, function(cb) {
+                        funcCalled = true;
+                        methods.getWidget(name, cb);
+                    }, {ttl: ttlFunc}, function(err, widget) {
+                        setTimeout(function() {
+                            checkErr(err);
+                            assert.deepEqual(widget, {name: name});
+                            assert.ok(memoryCache4.store.get.called);
+
+                            assert.ok(funcCalled);
+                            assert.ok(ttlFuncCalled);
+                            assert.ok(memoryCache4.store.set.called);
+                            done();
+                        }, 500);
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
This is a followup to #138 (a feature is not a feature if it has no bugs... )

* fix: option object passthrough and TTL calculation in multi-caching
* fix: Remove item from background queue if entry is not expired
* optimization: avoid running checks if refreshThreshold is not set (avoids some useless function calls)