### PR TITLE
add package.json browser entry and browser.js

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,11 @@
+module.exports = {
+    get(key) {
+        return localStorage.getItem(key); // eslint-disable-line no-undef
+    },
+    set(key, content) {
+        return localStorage.setItem(key, content); // eslint-disable-line no-undef
+    },
+    del(key) {
+        return localStorage.removeItem(key); // eslint-disable-line no-undef
+    }
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.0",
   "description": "Cache module for Node.js",
   "main": "index.js",
+  "module": "browser.js",
   "scripts": {
     "test": "make"
   },


### PR DESCRIPTION
It allows to ignore this dependency on browser, for example using webpack target: browser or rollup node-resolve browser option