### PR TITLE
Catch uncaught exception to pass it to callback

### DIFF
--- a/lib/multi_caching.js
+++ b/lib/multi_caching.js
@@ -150,7 +150,11 @@ var multiCaching = function(caches, options) {
                 _args.push(callback);
                 cache.store.mget.apply(cache.store, _args);
             } else {
-                cache.store.get(args[0], options, callback);
+                try {
+                    cache.store.get(args[0], options, callback);
+                } catch (err) {
+                    callback(err)   
+                }
             }
         }, function(err, result) {
             return cb(err, result);


### PR DESCRIPTION
Some error of underlying store, like memcached-plus, throw exception that is not capture and could propagate to main loop.
CF assertKey for exemple: https://github.com/victorquinn/memcache-plus/blob/master/lib/client.js#L16-L22.

Surround by try catch to capture and restore the error to the chain promise / callback.