### PR TITLE
Remove node-cache-manager-fs from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ See the [Express.js cache-manager example app](https://github.com/BryanDonovan/n
 
 * [node-cache-manager-mongoose](https://github.com/disjunction/node-cache-manager-mongoose)
 
-* [node-cache-manager-fs](https://github.com/hotelde/node-cache-manager-fs)
-
 * [node-cache-manager-fs-binary](https://github.com/sheershoff/node-cache-manager-fs-binary)
 
 * [node-cache-manager-fs-hash](https://github.com/rolandstarke/node-cache-manager-fs-hash)


### PR DESCRIPTION
I suggest to remove [node-cache-manager-fs](https://github.com/hotelde/node-cache-manager-fs) from the list of Store Engines of `README.md` because the lib is not working as expected.

After spending too much time checking my code, I tried another lib and it everything worked as expected.

I found out the lib has already a consequent number of issue related to the problem:
- https://github.com/hotelde/node-cache-manager-fs/issues/23
- https://github.com/hotelde/node-cache-manager-fs/issues/15
- https://github.com/hotelde/node-cache-manager-fs/issues/5
- https://github.com/hotelde/node-cache-manager-fs/issues/2

I recommend to use [node-cache-manager-fs-hash](https://github.com/rolandstarke/node-cache-manager-fs-hash) instead.