### PR TITLE
feat: add dump and load methods for memory store

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -186,6 +186,34 @@ var memoryStore = function(args) {
         }
     };
 
+    self.dump = function() {
+        var args = Array.prototype.slice.apply(arguments);
+        var cb;
+
+        if (typeof args[args.length - 1] === 'function') {
+            cb = args.pop();
+        }
+        var value = lruCache.dump();
+
+        if (cb) {
+            process.nextTick(cb.bind(null, null, value));
+        } else if (self.usePromises) {
+            return Promise.resolve(value);
+        } else {
+            return value;
+        }
+    };
+
+    self.load = function(cacheEntries, cb) {
+        lruCache.load(cacheEntries);
+
+        if (typeof cb === 'function') {
+            process.nextTick(cb.bind(null, null));
+        } else if (self.usePromises) {
+            return Promise.resolve();
+        }
+    };
+
     return self;
 };
 

--- a/test/stores/memory.unit.js
+++ b/test/stores/memory.unit.js
@@ -273,4 +273,103 @@ describe("memory store", function() {
             });
         });
     });
+
+    describe("dump()", function() {
+        var memoryCache;
+        var key1;
+        var value1;
+        var key2;
+        var value2;
+
+        beforeEach(function() {
+            key1 = support.random.string(20);
+            value1 = support.random.string();
+            key2 = support.random.string(20);
+            value2 = support.random.string();
+        });
+
+        it("lets us dump data without callback", function() {
+            memoryCache = memoryStore.create({noPromises: true});
+            memoryCache.set(key1, value1);
+            memoryCache.set(key2, value2);
+
+            const data = memoryCache.dump();
+            assert.equal(data[0].k, key2);
+            assert.equal(data[0].v, value2);
+            assert.equal(data[1].k, key1);
+            assert.equal(data[1].v, value1);
+        });
+
+        it("lets us dump data with callback", function() {
+            memoryCache = memoryStore.create({noPromises: true});
+            memoryCache.set(key1, value1);
+            memoryCache.set(key2, value2);
+
+            memoryCache.dump((err, data) => {
+                checkErr(err);
+                assert.equal(data[0].k, key2);
+                assert.equal(data[0].v, value2);
+                assert.equal(data[1].k, key1);
+                assert.equal(data[1].v, value1);
+            });
+        });
+
+        it("lets us dump data with Promise", async function() {
+            memoryCache = memoryStore.create();
+            memoryCache.set(key1, value1);
+            memoryCache.set(key2, value2);
+
+            const data = await memoryCache.dump();
+            assert.equal(data[0].k, key2);
+            assert.equal(data[0].v, value2);
+            assert.equal(data[1].k, key1);
+            assert.equal(data[1].v, value1);
+        });
+    });
+
+    describe("load()", function() {
+        var memoryCache;
+        var key1;
+        var value1;
+        var key2;
+        var value2;
+        var data;
+
+        beforeEach(function() {
+            key1 = support.random.string(20);
+            value1 = support.random.string();
+            key2 = support.random.string(20);
+            value2 = support.random.string();
+            data = [
+                {
+                    k: key1,
+                    v: value1
+                },
+                {
+                    k: key2,
+                    v: value2
+                }
+            ];
+        });
+
+        it("lets us load data with callback", function() {
+            memoryCache = memoryStore.create({noPromises: true});
+
+            memoryCache.load(data, err => {
+                checkErr(err);
+                assert.equal(memoryCache.get(key1), value1);
+                assert.equal(memoryCache.get(key2), value2);
+            });
+        });
+
+        it("lets us load data with callback", async function() {
+            memoryCache = memoryStore.create();
+
+            await memoryCache.load(data);
+
+            assert.equal(await memoryCache.get(key1), value1);
+            assert.equal(await memoryCache.get(key2), value2);
+        });
+
+    });
 });


### PR DESCRIPTION
PR for issue [How to use dump and load API since built-in memory cache is node-lru-cach](https://github.com/BryanDonovan/node-cache-manager/issues/169)

Add dump and load methods for memory store