### PR TITLE
fix: ttl not working

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -47,7 +47,7 @@ var memoryStore = function(args) {
         var length = keysValues.length;
         var values = [];
         for (var i = 0; i < length; i += 2) {
-            lruCache.set(keysValues[i], keysValues[i + 1], { ttl });
+            lruCache.set(keysValues[i], keysValues[i + 1], {ttl});
             values.push(keysValues[i + 1]);
         }
         return values;
@@ -66,7 +66,7 @@ var memoryStore = function(args) {
 
         var ttl = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
-        lruCache.set(key, value, { ttl });
+        lruCache.set(key, value, {ttl});
         if (cb) {
             process.nextTick(cb.bind(null, null));
         } else if (self.usePromises) {

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -33,7 +33,7 @@ var memoryStore = function(args) {
     var lruOpts = {
         max: args.max || 500,
         maxSize: args.maxSize,
-        ttl: (args.ttl || args.ttl === 0) ? args.ttl * 1000 : null,
+        ttl: (args.ttl || args.ttl === 0) ? args.ttl * 1000 : undefined,
         dispose: args.dispose,
         sizeCalculation: args.sizeCalculation || args.length,
         allowStale: args.allowStale || args.stale,

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -30,11 +30,10 @@ var memoryStore = function(args) {
     self.usePromises = !(typeof Promise === 'undefined' || args.noPromises);
     self.shouldCloneBeforeSet = args.shouldCloneBeforeSet !== false; // clone by default
 
-    var ttl = args.ttl;
     var lruOpts = {
         max: args.max || 500,
         maxSize: args.maxSize,
-        ttl: (ttl || ttl === 0) ? ttl * 1000 : null,
+        ttl: (args.ttl || args.ttl === 0) ? args.ttl * 1000 : null,
         dispose: args.dispose,
         sizeCalculation: args.sizeCalculation || args.length,
         allowStale: args.allowStale || args.stale,
@@ -44,11 +43,11 @@ var memoryStore = function(args) {
 
     var lruCache = new Lru(lruOpts);
 
-    var setMultipleKeys = function setMultipleKeys(keysValues, maxAge) {
+    var setMultipleKeys = function setMultipleKeys(keysValues, ttl) {
         var length = keysValues.length;
         var values = [];
         for (var i = 0; i < length; i += 2) {
-            lruCache.set(keysValues[i], keysValues[i + 1], maxAge);
+            lruCache.set(keysValues[i], keysValues[i + 1], { ttl });
             values.push(keysValues[i + 1]);
         }
         return values;
@@ -65,9 +64,9 @@ var memoryStore = function(args) {
         }
         options = options || {};
 
-        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
+        var ttl = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
-        lruCache.set(key, value, maxAge);
+        lruCache.set(key, value, { ttl });
         if (cb) {
             process.nextTick(cb.bind(null, null));
         } else if (self.usePromises) {
@@ -88,9 +87,9 @@ var memoryStore = function(args) {
             options = args.pop();
         }
 
-        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
+        var ttl = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
-        var values = setMultipleKeys(args, maxAge);
+        var values = setMultipleKeys(args, ttl);
 
         if (cb) {
             process.nextTick(cb.bind(null, null));

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -65,7 +65,7 @@ var memoryStore = function(args) {
         }
         options = options || {};
 
-        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.maxAge;
+        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
         lruCache.set(key, value, maxAge);
         if (cb) {
@@ -88,7 +88,7 @@ var memoryStore = function(args) {
             options = args.pop();
         }
 
-        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.maxAge;
+        var maxAge = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
         var values = setMultipleKeys(args, maxAge);
 


### PR DESCRIPTION
Hi, I upgraded to cache-manager@4.0.0 and TTL was not working.

Perhaps it was an omission in #193 updates.

* In lru-cache@7.x, `maxAge` was renamed to `ttl`.
* The `set()` function takes options objects instead of ttl integer.

See: https://github.com/isaacs/node-lru-cache/blob/main/CHANGELOG.md#specific-api-changes

## Versions

cache-manager: 4.0.0
lru-cache: 7.10.1
node: 18.2.0
npm: 8.9.0