### PR TITLE
feat: added support for ttl as the third arg in set function of memory store

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -64,6 +64,10 @@ var memoryStore = function(args) {
         }
         options = options || {};
 
+        if (options && typeof options === 'number') {
+            options = {ttl: options};
+        }
+
         var ttl = (options.ttl || options.ttl === 0) ? options.ttl * 1000 : lruOpts.ttl;
 
         lruCache.set(key, value, {ttl});

--- a/test/stores/memory.unit.js
+++ b/test/stores/memory.unit.js
@@ -37,6 +37,23 @@ describe("memory store", function() {
         });
     });
 
+    describe("ttl", function() {
+        var memoryCache;
+
+        beforeEach(function() {
+            memoryCache = memoryStore.create({noPromises: true, ttl: 0.001});
+        });
+
+        it("if options arg is a number in set()", function(done) {
+            memoryCache.set('foo', 'bar', 60);
+
+            setTimeout(function() {
+                assert.equal(memoryCache.get('foo'), 'bar');
+                done();
+            }, 10);
+        });
+    });
+
     describe("keyCount", function() {
         var memoryCache;
 

--- a/test/stores/memory.unit.js
+++ b/test/stores/memory.unit.js
@@ -52,6 +52,15 @@ describe("memory store", function() {
                 done();
             }, 10);
         });
+
+        it("cache record should be expired", function(done) {
+            memoryCache.set('foo', 'bar', 1);
+
+            setTimeout(function() {
+                assert.equal(memoryCache.get('foo'), undefined);
+                done();
+            }, 1500);
+        });
     });
 
     describe("keyCount", function() {


### PR DESCRIPTION
Added support for TTL seconds as the third argument in set() function of memory store strategy.
According to types from @types/cache-manager this function should support TTL in third arg but it can't. So this PR is fix this issue.
[Link to set() type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9b425ba3f0507dd34b52cfa39772b40975fc41ef/types/cache-manager/index.d.ts#L64``)